### PR TITLE
PR: Enhance KPM Indication Message, Reporting UE KPI(s), and RIC Control Message Handling

### DIFF
--- a/helper/indication-message-helper.cc
+++ b/helper/indication-message-helper.cc
@@ -78,7 +78,14 @@ IndicationMessageHelper::~IndicationMessageHelper ()
 Ptr<KpmIndicationMessage>
 IndicationMessageHelper::CreateIndicationMessage ()
 {
-  return Create<KpmIndicationMessage> (m_msgValues);
+  return Create<KpmIndicationMessage> (m_msgValues, std::map<std::string, std::any>{});
+}
+
+Ptr<KpmIndicationMessage>
+IndicationMessageHelper::CreateIndicationMessage (const std::map<std::string, std::any>& subcsDetails)
+{
+
+    return Create<KpmIndicationMessage>(m_msgValues,subcsDetails);
 }
 
 } // namespace ns3

--- a/helper/indication-message-helper.h
+++ b/helper/indication-message-helper.h
@@ -26,6 +26,7 @@
 #define INDICATION_MESSAGE_HELPER_H
 
 #include <ns3/kpm-indication.h>
+#include <any>
 
 namespace ns3 {
 
@@ -38,6 +39,7 @@ public:
   ~IndicationMessageHelper ();
 
   Ptr<KpmIndicationMessage> CreateIndicationMessage ();
+  Ptr<KpmIndicationMessage>CreateIndicationMessage (const std::map<std::string, std::any>& subsDetails);
 
   bool const &
   IsOffline () const

--- a/helper/mmwave-indication-message-helper.cc
+++ b/helper/mmwave-indication-message-helper.cc
@@ -20,6 +20,8 @@
  * Author: Andrea Lacava <thecave003@gmail.com>
  *		   Tommaso Zugno <tommasozugno@gmail.com>
  *		   Michele Polese <michele.polese@gmail.com>
+ *       Mina Yonan <mina.awadallah@orange.com>
+ *       Mostafa Ashraf <mostafa.ashraf.ext@orange.com>
  */
 
 #include <ns3/mmwave-indication-message-helper.h>
@@ -181,7 +183,10 @@ MmWaveIndicationMessageHelper::AddCuCpUePmItem (std::string ueImsiComplete, long
       ueVal->AddItem<long> ("DRB.RelActNbr.5QI.UEID", drbRelAct); // not modeled in the simulator
     }
 
+  // L3servingSINR3gpp_cell_XX
   ueVal->AddItem<Ptr<L3RrcMeasurements>> ("HO.SrcCellQual.RS-SINR.UEID", l3RrcMeasurementServing);
+  // L3servingSINR3gpp_cell_XX_UEID_XX
+  // L3neighSINR_cell_XX
   ueVal->AddItem<Ptr<L3RrcMeasurements>> ("HO.TrgtCellQual.RS-SINR.UEID", l3RrcMeasurementNeigh);
 
   m_msgValues.m_ueIndications.insert (ueVal);

--- a/helper/mmwave-indication-message-helper.h
+++ b/helper/mmwave-indication-message-helper.h
@@ -64,6 +64,10 @@ public:
   void AddCuCpUePmItem (std::string ueImsiComplete, long numDrb, long drbRelAct,
                         Ptr<L3RrcMeasurements> l3RrcMeasurementServing,
                         Ptr<L3RrcMeasurements> l3RrcMeasurementNeigh);
+  // void AddCuCpUePmItem (std::string ueImsiComplete, long numDrb, long drbRelAct,
+  //                       Ptr<L3RrcMeasurements> l3RrcMeasurementServing,
+  //                       Ptr<L3RrcMeasurements> l3RrcMeasurementNeigh, long m_cellId, long imsi,
+  //                         long sinrThisCell,  long convertedSinr);
 
 private:
 };

--- a/model/kpm-indication.cc
+++ b/model/kpm-indication.cc
@@ -72,6 +72,7 @@ extern "C" {
 #include "conversions.h"
 #include <assert.h>
 #include <cassert>
+#include <any>
 
 // #include "timing_ms.h"
 
@@ -353,9 +354,25 @@ KpmIndicationHeader::FillAndEncodeKpmRicIndicationHeader (E2SM_KPM_IndicationHea
   // TraceMessage (&asn_DEF_E2SM_KPM_IndicationHeader, header, "RIC Indication Header");
 }
 
-KpmIndicationMessage::KpmIndicationMessage (KpmIndicationMessageValues values)
+KpmIndicationMessage::KpmIndicationMessage (KpmIndicationMessageValues values,const std::map<std::string, std::any>& s_map) : SubscriptionR_map{s_map}
 {
   E2SM_KPM_IndicationMessage_t *descriptor = new E2SM_KPM_IndicationMessage_t ();
+  // printf("The map: %ld \n", s_map.size());
+  // for (const auto& pair : SubscriptionR_map) {
+  //   // Print the key
+  //   printf("The map2:\n");
+  //   printf("%s: ", pair.first.c_str());
+  //       if (pair.second.type() == typeid(int)) {
+  //           printf("%d\n", std::any_cast<int>(pair.second));
+  //       } else if (pair.second.type() == typeid(std::string)) {
+  //           printf("%s\n", std::any_cast<std::string>(pair.second).c_str());
+  //       } else if (pair.second.type() == typeid(double)) {
+  //           printf("%f\n", std::any_cast<double>(pair.second));
+  //       } else if (pair.second.type() == typeid(uint64_t)) {
+  //           printf("%lu\n", std::any_cast<uint64_t>(pair.second));
+  //       } else {
+  //           printf("Unknown type\n");
+  //       }}
   CheckConstraints (values);
   FillAndEncodeKpmIndicationMessage (descriptor, values);
   delete descriptor;

--- a/model/kpm-indication.cc
+++ b/model/kpm-indication.cc
@@ -354,7 +354,9 @@ KpmIndicationHeader::FillAndEncodeKpmRicIndicationHeader (E2SM_KPM_IndicationHea
   // TraceMessage (&asn_DEF_E2SM_KPM_IndicationHeader, header, "RIC Indication Header");
 }
 
-KpmIndicationMessage::KpmIndicationMessage (KpmIndicationMessageValues values,const std::map<std::string, std::any>& s_map) : SubscriptionR_map{s_map}
+KpmIndicationMessage::KpmIndicationMessage (KpmIndicationMessageValues values,
+                                            const std::map<std::string, std::any> &s_map)
+    : SubscriptionR_map{s_map}
 {
   E2SM_KPM_IndicationMessage_t *descriptor = new E2SM_KPM_IndicationMessage_t ();
   // printf("The map: %ld \n", s_map.size());
@@ -828,13 +830,13 @@ KpmIndicationMessage::getMesDataItem (const MeasResultListNR *_measResultListNR,
   MeasurementDataItem_t *measure_data_item =
       (MeasurementDataItem_t *) calloc (1, sizeof (MeasurementDataItem_t));
 
-
   for (int i = 0; i < _measResultListNR->list.count; i++)
     {
-      if(*(_measResultListNR->list.array[i]->physCellId) < 0) {
+      if (*(_measResultListNR->list.array[i]->physCellId) < 0)
+        {
           updateNeighMsg (measurmentType, IMSI, *(_measResultListNR->list.array[i]->physCellId));
           continue;
-      }
+        }
       MeasurementRecordItem_t *measure_record_item2 =
           (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
       measure_record_item2->present = MeasurementRecordItem_PR_integer;
@@ -887,7 +889,8 @@ KpmIndicationMessage::updateServingMsg (MeasurementType_t *measurmentType, const
 }
 
 void
-KpmIndicationMessage::updateNeighMsg (MeasurementType_t *measurmentType, const OCTET_STRING_t &IMSI, const int &cellID)
+KpmIndicationMessage::updateNeighMsg (MeasurementType_t *measurmentType, const OCTET_STRING_t &IMSI,
+                                      const int &cellID)
 {
   // 0.371 enbdev 2 UE 1 L3 neigh 4 SINR -19.4777 sinr encoded 7 first insert
   std::ostringstream oss;
@@ -994,7 +997,16 @@ KpmIndicationMessage::FillKpmIndicationMessageFormat1 (
   // 3. Adding Granularity Period
   GranularityPeriod_t *granPeriodMS =
       (GranularityPeriod_t *) calloc (1, sizeof (GranularityPeriod_t));
-  *granPeriodMS = 100;
+  if (SubscriptionR_map.find ("Granularity Period") != SubscriptionR_map.end ())
+    {
+      *granPeriodMS = std::any_cast<GranularityPeriod_t> (SubscriptionR_map["Granularity Period"]);
+    }
+  else
+    {
+      // TODO: replace by global system preodicity(GranularityPeriod).
+      // TODO: Abort
+      *granPeriodMS = 100;
+    }
 
   ind_msg_f_1->measData = *measurementDataList;
   ind_msg_f_1->measInfoList = infoList;

--- a/model/kpm-indication.cc
+++ b/model/kpm-indication.cc
@@ -21,53 +21,57 @@
  * Author: Andrea Lacava <thecave003@gmail.com>
  *		   Tommaso Zugno <tommasozugno@gmail.com>
  *		   Michele Polese <michele.polese@gmail.com>
+ *       Mina Yonan <mina.awadallah@orange.com>
  *       Mostafa Ashraf <mostafa.ashraf.ext@orange.com>
  *       Aya Kamal <aya.kamal.ext@orange.com>
  *       Abdelrhman Soliman <abdelrhman.soliman.ext@orange.com>
  */
 
 #include <ns3/kpm-indication.h>
+// #include "kpm-indication.h"
 
 #include <ns3/asn1c-types.h>
 #include <ns3/log.h>
 
 extern "C" {
-#include "E2SM-KPM-IndicationHeader-Format1.h"
-#include "E2SM-KPM-IndicationMessage-Format1.h"
-#include "GlobalE2node-ID.h"
-#include "GlobalE2node-gNB-ID.h"
-#include "GlobalE2node-eNB-ID.h"
-#include "GlobalE2node-ng-eNB-ID.h"
-#include "GlobalE2node-en-gNB-ID.h"
-#include "NRCGI.h"
-#include "PM-Containers-Item.h"
-#include "RIC-EventTriggerStyle-Item.h"
-#include "RIC-ReportStyle-Item.h"
-#include "TimeStamp.h"
-#include "CUUPMeasurement-Container.h"
-#include "PlmnID-Item.h"
-#include "EPC-CUUP-PM-Format.h"
-#include "PerQCIReportListItemFormat.h"
-#include "PerUE-PM-Item.h"
-#include "PM-Info-Item.h"
-#include "MeasurementInfoList.h"
-#include "CellObjectID.h"
-#include "CellResourceReportListItem.h"
-#include "ServedPlmnPerCellListItem.h"
-#include "EPC-DU-PM-Container.h"
-#include "PerQCIReportListItem.h"
-//==============================================================
-#include "MeasurementRecordItem.h"
-#include "MeasurementDataItem.h"
-#include "MeasurementInfoItem.h"
-#include "LabelInfoItem.h"
-#include "MeasurementLabel.h"
-#include "E2SM-KPM-IndicationMessage-Format3.h"
-#include "UEMeasurementReportItem.h"
-#include "UEID-GNB.h"
+// #include "E2SM-KPM-IndicationHeader-Format1.h"
+// #include "E2SM-KPM-IndicationMessage-Format1.h"
+// #include "GlobalE2node-ID.h"
+// #include "GlobalE2node-gNB-ID.h"
+// #include "GlobalE2node-eNB-ID.h"
+// #include "GlobalE2node-ng-eNB-ID.h"
+// #include "GlobalE2node-en-gNB-ID.h"
+// #include "NRCGI.h"
+// #include "PM-Containers-Item.h"
+// #include "RIC-EventTriggerStyle-Item.h"
+// #include "RIC-ReportStyle-Item.h"
+// #include "TimeStamp.h"
+// #include "CUUPMeasurement-Container.h"
+// #include "PlmnID-Item.h"
+// #include "EPC-CUUP-PM-Format.h"
+// #include "PerQCIReportListItemFormat.h"
+// #include "PerUE-PM-Item.h"
+// #include "PM-Info-Item.h"
+// #include "MeasurementInfoList.h"
+// #include "CellObjectID.h"
+// #include "CellResourceReportListItem.h"
+// #include "ServedPlmnPerCellListItem.h"
+// #include "EPC-DU-PM-Container.h"
+// #include "PerQCIReportListItem.h"
+// //==============================================================
+// #include "MeasurementRecordItem.h"
+// #include "MeasurementDataItem.h"
+// #include "MeasurementInfoItem.h"
+// #include "LabelInfoItem.h"
+// #include "MeasurementLabel.h"
+// #include "E2SM-KPM-IndicationMessage-Format3.h"
+// #include "UEMeasurementReportItem.h"
+// #include "UEID-GNB.h"
 #include <arpa/inet.h>
 
 #include "conversions.h"
+#include <assert.h>
+#include <cassert>
 
 // #include "timing_ms.h"
 
@@ -108,60 +112,67 @@ KpmIndicationHeader::~KpmIndicationHeader ()
   m_size = 0;
 }
 
-uint64_t KpmIndicationHeader::time_now_us_clck() {
+uint64_t
+KpmIndicationHeader::time_now_us_clck ()
+{
   struct timespec tms;
 
   /* The C11 way */
   /* if (! timespec_get(&tms, TIME_UTC))  */
 
   /* POSIX.1-2008 way */
-  if (clock_gettime(CLOCK_REALTIME,&tms)) {
-    return -1;
-  }
+  if (clock_gettime (CLOCK_REALTIME, &tms))
+    {
+      return -1;
+    }
   /* seconds, multiplied with 1 million */
   uint64_t micros = tms.tv_sec * 1000000;
   /* Add full microseconds */
-  micros += tms.tv_nsec/1000;
+  micros += tms.tv_nsec / 1000;
   /* round up if necessary */
-  if (tms.tv_nsec % 1000 >= 500) {
-    ++micros;
-  }
-  NS_LOG_INFO("**micros Timing is " << micros);
+  if (tms.tv_nsec % 1000 >= 500)
+    {
+      ++micros;
+    }
+  NS_LOG_INFO ("**micros Timing is " << micros);
   return micros;
 }
 
-// KPM ind_msg latency 
-OCTET_STRING_t KpmIndicationHeader::get_time_now_us() {
+// KPM ind_msg latency
+OCTET_STRING_t
+KpmIndicationHeader::get_time_now_us ()
+{
 
-  std::vector<uint8_t> byteArray(sizeof(uint64_t));
+  std::vector<uint8_t> byteArray (sizeof (uint64_t));
 
-  auto val = time_now_us_clck();
+  auto val = time_now_us_clck ();
 
   // NS_LOG_DEBUG("**VAL Timing is " << val);
 
-  memcpy(byteArray.data(), &val, sizeof(uint64_t));
+  memcpy (byteArray.data (), &val, sizeof (uint64_t));
 
   // NS_LOG_DEBUG("ByteArray Size is " << byteArray.size());
-  
-  OCTET_STRING_t dst = {0};
-  
-  dst.buf = (uint8_t*)calloc(byteArray.size(), sizeof(uint8_t)); 
-  dst.size = byteArray.size();
 
-  memcpy(dst.buf, byteArray.data(), dst.size);
+  OCTET_STRING_t dst = {0};
+
+  dst.buf = (uint8_t *) calloc (byteArray.size (), sizeof (uint8_t));
+  dst.size = byteArray.size ();
+
+  memcpy (dst.buf, byteArray.data (), dst.size);
 
   return dst;
 }
 
-OCTET_STRING_t KpmIndicationHeader::int_64_to_octet_string(uint64_t x)
+OCTET_STRING_t
+KpmIndicationHeader::int_64_to_octet_string (uint64_t x)
 {
-    OCTET_STRING_t asn = {0};
+  OCTET_STRING_t asn = {0};
 
-    asn.buf = (uint8_t*) calloc(sizeof(x) + 1, sizeof(char));
-    memcpy(asn.buf,&x,sizeof(x));
-    asn.size = sizeof(x);
+  asn.buf = (uint8_t *) calloc (sizeof (x) + 1, sizeof (char));
+  memcpy (asn.buf, &x, sizeof (x));
+  asn.size = sizeof (x);
 
-    return asn;
+  return asn;
 }
 
 // OCTET_STRING_t KpmIndicationHeader::int_64_to_octet_string(uint64_t value)
@@ -171,7 +182,7 @@ OCTET_STRING_t KpmIndicationHeader::int_64_to_octet_string(uint64_t x)
 
 //   OCTET_STRING_t dst = {0};
 
-//   dst.buf = (uint8_t*)calloc(byteArray.size(), sizeof(uint8_t)); 
+//   dst.buf = (uint8_t*)calloc(byteArray.size(), sizeof(uint8_t));
 //   dst.size = byteArray.size();
 
 //   memcpy(dst.buf, byteArray.data(), dst.size);
@@ -179,13 +190,14 @@ OCTET_STRING_t KpmIndicationHeader::int_64_to_octet_string(uint64_t x)
 //   return dst;
 // }
 
-uint64_t KpmIndicationHeader::octet_string_to_int_64(OCTET_STRING_t asn)
+uint64_t
+KpmIndicationHeader::octet_string_to_int_64 (OCTET_STRING_t asn)
 {
-    uint64_t x = {0};
+  uint64_t x = {0};
 
-    memcpy(&x, asn.buf, asn.size);
+  memcpy (&x, asn.buf, asn.size);
 
-    return x;
+  return x;
 }
 
 void
@@ -207,12 +219,14 @@ KpmIndicationHeader::Encode (E2SM_KPM_IndicationHeader_t *descriptor)
   m_size = encodedHeader.result.encoded;
 }
 
-uint64_t ntohll(uint64_t val) {
-    uint32_t high = ntohl((uint32_t)(val >> 32));  // Convert high 32 bits
-    uint32_t low = ntohl((uint32_t)(val & 0xFFFFFFFF));  // Convert low 32 bits
-
-    return ((uint64_t)high << 32) | low;  // Combine the high and low 32 bits back together
+uint64_t
+ntohll (uint64_t val)
+{
+  uint32_t high = ntohl ((uint32_t) (val >> 32)); // Convert high 32 bits
+  uint32_t low = ntohl ((uint32_t) (val & 0xFFFFFFFF)); // Convert low 32 bits
+  return ((uint64_t) high << 32) | low; // Combine the high and low 32 bits back together
 }
+
 void
 KpmIndicationHeader::FillAndEncodeKpmRicIndicationHeader (E2SM_KPM_IndicationHeader_t *descriptor,
                                                           KpmRicIndicationHeaderValues values)
@@ -226,28 +240,26 @@ KpmIndicationHeader::FillAndEncodeKpmRicIndicationHeader (E2SM_KPM_IndicationHea
   Ptr<BitString> cellId_bstring;
   TimeStamp_t colstartTime;
 
-  colstartTime = get_time_now_us();
-// Convert from OCTET STRING to uint64
-uint64_t original_time;
-memcpy(&original_time, colstartTime.buf, sizeof(uint64_t));
+  colstartTime = get_time_now_us ();
+  // Convert from OCTET STRING to uint64
+  uint64_t original_time;
+  memcpy (&original_time, colstartTime.buf, sizeof (uint64_t));
 
-// Convert to network byte order
-uint64_t network_order_time = ntohll(original_time);
+  // Convert to network byte order
+  uint64_t network_order_time = ntohll (original_time);
 
-// Assign network_order_time back to colletStartTime as an OCTET_STRING
-ind_header->colletStartTime.buf = (uint8_t *)calloc(8, sizeof(uint8_t));
-memcpy(ind_header->colletStartTime.buf, &network_order_time, sizeof(uint64_t));
-ind_header->colletStartTime.size = sizeof(uint64_t);
+  // Assign network_order_time back to colletStartTime as an OCTET_STRING
+  ind_header->colletStartTime.buf = (uint8_t *) calloc (8, sizeof (uint8_t));
+  memcpy (ind_header->colletStartTime.buf, &network_order_time, sizeof (uint64_t));
+  ind_header->colletStartTime.size = sizeof (uint64_t);
 
-  
-   NS_LOG_INFO(" LOOOOOK -> colletStartTime " << octet_string_to_int_64(ind_header->colletStartTime));
+  NS_LOG_INFO (" LOOOOOK -> colletStartTime "
+               << octet_string_to_int_64 (ind_header->colletStartTime));
   GlobalE2node_ID_t *globalE2nodeIdBuf = (GlobalE2node_ID *) calloc (1, sizeof (GlobalE2node_ID));
-
 
   switch (m_nodeType)
     {
-    case gNB:
-      {
+      case gNB: {
 
         NS_LOG_INFO ("gNB Header");
         static int sizeGnb = 4; // 3GPP Specs
@@ -264,8 +276,7 @@ ind_header->colletStartTime.size = sizeof(uint64_t);
       }
       break;
 
-    case eNB:
-      {
+      case eNB: {
         // Use this.
         NS_LOG_INFO ("eNB Header");
         static int sizeEnb =
@@ -284,8 +295,7 @@ ind_header->colletStartTime.size = sizeof(uint64_t);
       }
       break;
 
-    case ng_eNB:
-      {
+      case ng_eNB: {
         NS_LOG_INFO ("ng_eNB Header");
 
         static int sizeEnb =
@@ -306,8 +316,7 @@ ind_header->colletStartTime.size = sizeof(uint64_t);
       }
       break;
 
-    case en_gNB:
-      {
+      case en_gNB: {
         NS_LOG_INFO ("en_gNB Header");
 
         static int sizeGnb = 4; // 3GPP Specs
@@ -362,6 +371,7 @@ void
 KpmIndicationMessage::CheckConstraints (KpmIndicationMessageValues values)
 {
   // TODO remove?
+  NS_LOG_DEBUG ("m_cellObjectId=" << values.m_cellObjectId);
   // if (values.m_crnti.length () != 2)
   //   {
   //     NS_FATAL_ERROR ("C-RNTI should have length 2");
@@ -387,14 +397,11 @@ void
 KpmIndicationMessage::Encode (E2SM_KPM_IndicationMessage_t *descriptor)
 {
 
-  const bool USER_PRIVATE_BUFFER = true;
-  if (USER_PRIVATE_BUFFER)
+  const bool USE_PRIVATE_BUFFER = false;
+  if (USE_PRIVATE_BUFFER)
     {
 
-
       darsh_byte_array_t ba_darsh = {.buf = (uint8_t *) malloc (2048), .len = 2048};
-      // byte_array_t ba_darsh = {.len = 2048, .buf = (uint8_t *) malloc (2048)};
-
       asn_enc_rval_t encodedMsg =
           asn_encode_to_buffer (NULL, ATS_ALIGNED_BASIC_PER, &asn_DEF_E2SM_KPM_IndicationMessage,
                                 descriptor, ba_darsh.buf, ba_darsh.len);
@@ -410,7 +417,12 @@ KpmIndicationMessage::Encode (E2SM_KPM_IndicationMessage_t *descriptor)
           NS_LOG_INFO ("Error during encoding ");
         }
 
-      assert(encodedMsg.encoded > -1 && (size_t)encodedMsg.encoded <= ba_darsh.len);
+      NS_LOG_LOGIC ("encodedMsg.encoded=" << encodedMsg.encoded);
+      NS_LOG_LOGIC ("ba_darsh.len=" << ba_darsh.len);
+
+      assert (encodedMsg.encoded > -1);
+      assert ((size_t) encodedMsg.encoded <= ba_darsh.len);
+
       m_buffer = ba_darsh.buf;
       m_size = encodedMsg.encoded;
     }
@@ -510,7 +522,7 @@ KpmIndicationMessage::FillOCuCpContainer (PF_Container_t *ranContainer,
 {
   OCUCP_PF_Container_t *ocucp = (OCUCP_PF_Container_t *) calloc (1, sizeof (OCUCP_PF_Container_t));
   long *numActiveUes = (long *) calloc (1, sizeof (long));
-  *numActiveUes = long(values->m_numActiveUes);
+  *numActiveUes = long (values->m_numActiveUes);
   ocucp->cu_CP_Resource_Status.numberOfActive_UEs = numActiveUes;
   ranContainer->choice.oCU_CP = ocucp;
   ranContainer->present = PF_Container_PR_oCU_CP;
@@ -566,7 +578,7 @@ KpmIndicationMessage::FillODuContainer (PF_Container_t *ranContainer,
               long *dlUsedPrbs = (long *) calloc (1, sizeof (long));
               *dlUsedPrbs = perQciReportItem->m_dlPrbUsage;
               pqrl->dl_PRBUsage = dlUsedPrbs;
-              NS_LOG_LOGIC ("DL PRBs " << dlUsedPrbs);
+              NS_LOG_LOGIC ("DL PRBs " << *dlUsedPrbs);
 
               NS_ABORT_MSG_IF ((perQciReportItem->m_ulPrbUsage < 0) |
                                    (perQciReportItem->m_ulPrbUsage > 100),
@@ -584,305 +596,595 @@ KpmIndicationMessage::FillODuContainer (PF_Container_t *ranContainer,
   ranContainer->choice.oDU = odu;
   ranContainer->present = PF_Container_PR_oDU;
 }
-// void KpmIndicationMessage::AddMeasurementType() {
 
-// }
-void
-KpmIndicationMessage::FillAndEncodeKpmIndicationMessage (E2SM_KPM_IndicationMessage_t *descriptor,
-                                                         KpmIndicationMessageValues values)
+// int KpmIndicationMessage::count = 0;
+// std::mutex KpmIndicationMessage::mtx;
+
+std::pair<MeasurementInfoItem_t *, MeasurementDataItem_t *>
+KpmIndicationMessage::getMesInfoItem (const Ptr<MeasurementItem> &mesItem)
 {
 
-  const bool ENABLE_FORMAT_ONE = false;
+  // // 1. Adding a measurement values(item) to the packet.
+  MeasurementDataItem_t *measureDataItem = nullptr;
 
-  if (ENABLE_FORMAT_ONE)
+  auto item = mesItem->GetValue ();
+
+  MeasurementType_t *measurmentType = (MeasurementType_t *) calloc (1, sizeof (MeasurementType_t));
+  *measurmentType = item.pmType;
+
+  if (item.pmType.present == MeasurementType_PR_measName)
     {
-      // Format 1
-      // MOCK for buiding KPM Indication messages
+      switch (item.pmVal.present)
+        {
+          case MeasurementValue_PR_NOTHING: {
+            NS_LOG_INFO ("\n MeasurementValue_PR_NOTHING");
+            break;
+          }
+          case MeasurementValue_PR_valueInt: {
+            NS_LOG_INFO ("\n 	MeasurementValue_PR_valueInt" << item.pmVal.choice.valueInt);
+            measureDataItem = getMesDataItem (static_cast<double> (item.pmVal.choice.valueInt));
+            break;
+          }
+          case MeasurementValue_PR_valueReal: {
+            NS_LOG_INFO ("\n MeasurementValue_PR_valueReal" << item.pmVal.choice.valueReal);
+            measureDataItem = getMesDataItem (item.pmVal.choice.valueReal);
+            break;
+          }
+          case MeasurementValue_PR_noValue: {
+            NS_LOG_INFO ("\n MeasurementValue_PR_noValue" << item.pmVal.choice.noValue);
+            break;
+          }
+          case MeasurementValue_PR_valueRRC: {
+            // LabelInfoList_t *labelInfoolist = (LabelInfoList_t *) calloc (1, sizeof (LabelInfoList_t));
 
-      E2SM_KPM_IndicationMessage_t *ind_message =
-          (E2SM_KPM_IndicationMessage_t *) calloc (1, sizeof (E2SM_KPM_IndicationMessage_t));
+            auto measName =
+                std::string (reinterpret_cast<const char *> (item.pmType.choice.measName.buf),
+                             item.pmType.choice.measName.size);
+            NS_LOG_INFO ("\n 	item.pmType.choice.measName" << measName);
 
-      E2SM_KPM_IndicationMessage_Format1_t *test_kpm_ind_message =
-          (E2SM_KPM_IndicationMessage_Format1_t *) calloc (
-              1, sizeof (E2SM_KPM_IndicationMessage_Format1_t));
+            // Fill Neighbours cells of 5G, MeasResultNeighCells_PR_measResultListNR
+            L3_RRC_Measurements *rrc = item.pmVal.choice.valueRRC;
 
-      MeasurementRecord_t *measure_record =
-          (MeasurementRecord_t *) calloc (1, sizeof (MeasurementRecord_t));
+            if (measName == "HO.TrgtCellQual.RS-SINR.UEID")
+              {
+                if (rrc->measResultNeighCells != nullptr &&
+                    rrc->measResultNeighCells->present == MeasResultNeighCells_PR_measResultListNR)
+                  {
+                    assert (rrc->measResultNeighCells->choice.measResultListNR != nullptr);
+                    try
+                      {
+                        if (rrc->measResultNeighCells->choice.measResultListNR->list.count > 0)
+                          {
+                            MeasResultListNR *_measResultListNR =
+                                rrc->measResultNeighCells->choice.measResultListNR;
+                            measureDataItem = getMesDataItem (_measResultListNR);
+                          }
 
-      MeasurementRecordItem_t *measure_record_item =
-          (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
-      measure_record_item->present = MeasurementRecordItem_PR_integer;
-      measure_record_item->choice.integer = 1;
+                    } catch (const std::exception &e)
+                      {
+                        std::cerr << "Error is" << e.what () << '\n';
+                    }
+                  }
+              }
+            else if (measName == "HO.SrcCellQual.RS-SINR.UEID")
+              {
+                if (rrc->servingCellMeasurements != nullptr &&
+                    rrc->servingCellMeasurements->present ==
+                        ServingCellMeasurements_PR_nr_measResultServingMOList)
+                  {
+                    assert (rrc->servingCellMeasurements->choice.nr_measResultServingMOList !=
+                            nullptr);
+                    try
+                      {
+                        if (rrc->servingCellMeasurements->choice.nr_measResultServingMOList->list
+                                .count > 0)
+                          {
+                            MeasResultServMOList *_MeasResultServMO =
+                                rrc->servingCellMeasurements->choice.nr_measResultServingMOList;
+                            measureDataItem = getMesDataItem (_MeasResultServMO);
+                          }
+                    } catch (const std::exception &e)
+                      {
+                        std::cerr << "Error is" << e.what () << '\n';
+                    }
+                  }
+              }
+            else
+              {
+                NS_LOG_INFO ("\n 	L3_RRC_Measurement but not handled, measName" << measName);
+              }
 
-      ASN_SEQUENCE_ADD (&measure_record->list, measure_record_item);
-
-      MeasurementDataItem_t *measure_data_item =
-          (MeasurementDataItem_t *) calloc (1, sizeof (MeasurementDataItem_t));
-
-      measure_data_item->measRecord = *measure_record;
-
-      MeasurementData_t *measurement_data =
-          (MeasurementData_t *) calloc (1, sizeof (MeasurementData_t));
-
-      ASN_SEQUENCE_ADD (&measurement_data->list, measure_data_item);
-
-      test_kpm_ind_message->measData = *measurement_data;
-
-      ind_message->indicationMessage_formats.present =
-          E2SM_KPM_IndicationMessage__indicationMessage_formats_PR_indicationMessage_Format1;
-
-      ind_message->indicationMessage_formats.choice.indicationMessage_Format1 =
-          test_kpm_ind_message;
-
-      // ASN_SEQUENCE_ADD(&ind_message->indicationMessage_formats.choice.indicationMessage_Format1, test_kpm_ind_message) ;
-
-      Encode (ind_message);
+            break;
+          }
+          default: {
+            break;
+          }
+        }
     }
   else
     {
+      NS_LOG_INFO ("\n 	item.pmType.choice.measID" << item.pmType.choice.measID);
+    }
 
-      // Format 3 Section
+  MeasurementLabel_t *measure_label =
+      (MeasurementLabel_t *) calloc (1, sizeof (MeasurementLabel_t));
+  measure_label->noLabel = (long *) malloc (sizeof (long));
+  assert (measure_label->noLabel != NULL && "Memory exhausted");
+  *measure_label->noLabel = 0;
+  LabelInfoItem_t *LabelInfoItem = (LabelInfoItem_t *) calloc (1, sizeof (LabelInfoItem_t));
+  LabelInfoItem->measLabel = *measure_label;
+  LabelInfoList_t *labelInfoolist = (LabelInfoList_t *) calloc (1, sizeof (LabelInfoList_t));
+  ASN_SEQUENCE_ADD (&labelInfoolist->list, LabelInfoItem);
 
-      // Format 3 sections,
-      // consists of format 1 and some additional args like (UE_ID, and Measurements report) and these are mandatory args.
+  MeasurementInfoItem_t *infoItem =
+      (MeasurementInfoItem_t *) calloc (1, sizeof (MeasurementInfoItem_t));
 
-      // Format 1 Part
-      E2SM_KPM_IndicationMessage_t *ind_message =
-          (E2SM_KPM_IndicationMessage_t *) calloc (1, sizeof (E2SM_KPM_IndicationMessage_t));
+  infoItem->labelInfoList = *labelInfoolist;
+  infoItem->measType = *measurmentType;
 
-      // 1. Adding a measurement values(item) to the packet.
-      MeasurementRecord_t *measure_record =
-          (MeasurementRecord_t *) calloc (1, sizeof (MeasurementRecord_t));
+  return std::make_pair (infoItem, measureDataItem);
+}
+
+MeasurementDataItem_t *
+KpmIndicationMessage::getMesDataItem (const double &realVal)
+{
+
+  // 1. Adding a measurement values(item) to the packet.
+  MeasurementRecord_t *measure_record =
+      (MeasurementRecord_t *) calloc (1, sizeof (MeasurementRecord_t));
+
+  MeasurementRecordItem_t *measure_record_item =
+      (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
+
+  measure_record_item->present = MeasurementRecordItem_PR_real;
+  measure_record_item->choice.real = realVal;
+
+  // Stream measurement records to list.
+  ASN_SEQUENCE_ADD (&measure_record->list, measure_record_item);
+
+  MeasurementDataItem_t *measure_data_item =
+      (MeasurementDataItem_t *) calloc (1, sizeof (MeasurementDataItem_t));
+
+  measure_data_item->measRecord = *measure_record;
+
+  return measure_data_item;
+}
+
+MeasurementDataItem_t *
+KpmIndicationMessage::getMesDataItem (const MeasResultServMOList *_MeasResultServMOList)
+{
+
+  MeasurementRecord_t *measure_record =
+      (MeasurementRecord_t *) calloc (1, sizeof (MeasurementRecord_t));
+
+  MeasurementDataItem_t *measure_data_item =
+      (MeasurementDataItem_t *) calloc (1, sizeof (MeasurementDataItem_t));
+
+  for (int i = 0; i < _MeasResultServMOList->list.count; i++)
+    {
+      MeasurementRecordItem_t *measure_record_item1 =
+          (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
+      measure_record_item1->present = MeasurementRecordItem_PR_integer;
+      measure_record_item1->choice.integer =
+          static_cast<unsigned long> (_MeasResultServMOList->list.array[i]->servCellId);
+
+      MeasurementRecordItem_t *measure_record_item2 =
+          (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
+      measure_record_item2->present = MeasurementRecordItem_PR_integer;
+      measure_record_item2->choice.integer = static_cast<unsigned long> (
+          *(_MeasResultServMOList->list.array[i]->measResultServingCell.physCellId));
+
+      MeasurementRecordItem_t *measure_record_item3 =
+          (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
+      measure_record_item3->present = MeasurementRecordItem_PR_real;
+      measure_record_item3->choice.real =
+          *(_MeasResultServMOList->list.array[i]
+                ->measResultServingCell.measResult.cellResults.resultsSSB_Cell->sinr);
+
+      // Stream measurement records to list.
+      ASN_SEQUENCE_ADD (&measure_record->list, measure_record_item1);
+      ASN_SEQUENCE_ADD (&measure_record->list, measure_record_item2);
+      ASN_SEQUENCE_ADD (&measure_record->list, measure_record_item3);
+    }
+
+  measure_data_item->measRecord = *measure_record;
+
+  return measure_data_item;
+}
+
+MeasurementDataItem_t *
+KpmIndicationMessage::getMesDataItem (const MeasResultListNR *_measResultListNR)
+{
+
+  MeasurementRecord_t *measure_record =
+      (MeasurementRecord_t *) calloc (1, sizeof (MeasurementRecord_t));
+
+  MeasurementDataItem_t *measure_data_item =
+      (MeasurementDataItem_t *) calloc (1, sizeof (MeasurementDataItem_t));
+
+  for (int i = 0; i < _measResultListNR->list.count; i++)
+    {
+      MeasurementRecordItem_t *measure_record_item2 =
+          (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
+      measure_record_item2->present = MeasurementRecordItem_PR_integer;
+      measure_record_item2->choice.integer = *(_measResultListNR->list.array[i]->physCellId);
 
       MeasurementRecordItem_t *measure_record_item =
           (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
-      // measure_record_item->present = MeasurementRecordItem_PR_integer;
-      // measure_record_item->choice.integer = 1;
 
       measure_record_item->present = MeasurementRecordItem_PR_real;
-      measure_record_item->choice.real = 0;//(rand() % 256) + 0.1;
+      measure_record_item->choice.real =
+          *(_measResultListNR->list.array[i]
+                ->measResult.cellResults.resultsSSB_Cell->sinr); //(rand() % 256) + 0.1;
 
       // Stream measurement records to list.
+      ASN_SEQUENCE_ADD (&measure_record->list, measure_record_item2);
       ASN_SEQUENCE_ADD (&measure_record->list, measure_record_item);
+    }
 
-      MeasurementDataItem_t *measure_data_item =
-          (MeasurementDataItem_t *) calloc (1, sizeof (MeasurementDataItem_t));
+  measure_data_item->measRecord = *measure_record;
 
-      measure_data_item->measRecord = *measure_record;
+  return measure_data_item;
+}
 
-      MeasurementData_t *measurement_data =
-          (MeasurementData_t *) calloc (1, sizeof (MeasurementData_t));
+// E-UTRA is the air interface of 3rd Generation Partnership Project (3GPP)
+// Long Term Evolution (LTE) upgrade path for mobile networks.
 
-      ASN_SEQUENCE_ADD (&measurement_data->list, measure_data_item);
+// ueVal->AddItem<Ptr<L3RrcMeasurements>> ("HO.SrcCellQual.RS-SINR.UEID", l3RrcMeasurementServing);
+// ueVal->AddItem<Ptr<L3RrcMeasurements>> ("HO.TrgtCellQual.RS-SINR.UEID", l3RrcMeasurementNeigh);
+// RIC Style 4 cellID, UserID, SINR Map
+// Event trigger - PrbUsage
+// 0.371 enbdev 2 UE 3 L3 neigh 3 SINR -3.92736 sinr encoded 38 first insert
+// 0.371 enbdev 2 UE 3 L3 neigh 4 SINR -11.9135 sinr encoded 22 first insert
+// 0.371 enbdev 2 UE 4 L3 serving SINR -13.7703 L3 serving SINR 3gpp 19
+// 0.371 enbdev 2 UE 4 L3 neigh 4 SINR -10.8886 sinr encoded 24 first insert
+// 0.371 enbdev 2 UE 4 L3 neigh 3 SINR -34.2883 sinr encoded 0 first insert
+// 0.371 enbdev 2 UE 1 L3 serving SINR -0.616781 L3 serving SINR 3gpp 45
+// 0.371 enbdev 2 UE 1 L3 neigh 3 SINR -9.88701 sinr encoded 26 first insert
 
+std::string
+servingMsg (const int &cellID, const int &UeID)
+{
+  // 0.371 enbdev 2 UE 3 L3 serving SINR 3.28529 L3 serving SINR 3gpp 53
+  std::ostringstream oss;
+  // L3servingSINR3gpp_cell_XX
+  // L3servingSINR3gpp_cell_XX_UEID_XX
+  oss << "L3servingSINR3gpp_cell_" << cellID << "_UEID_" << UeID;
+  return oss.str ();
+}
 
-      // 2. TODO: Optional, but mandatory for flex ric "Fix warning commit".
-      /*
-      
-        m_measName =
+std::string
+neighMsg (const int &cellID)
+{
+  // 0.371 enbdev 2 UE 1 L3 neigh 4 SINR -19.4777 sinr encoded 7 first insert
+  std::ostringstream oss;
+  // L3neighSINR_cell_XX
+  oss << "L3neighSINR_cell_" << cellID;
+  // return std::move (oss.str ());
+  return oss.str ();
+}
+
+void
+KpmIndicationMessage::FillKpmIndicationMessageFormat1 (
+    E2SM_KPM_IndicationMessage_Format1 *ind_msg_f_1)
+{
+  // 1. Adding a measurement values (item) to the packet.
+  MeasurementData_t *measurement_data =
+      (MeasurementData_t *) calloc (1, sizeof (MeasurementData_t));
+
+  MeasurementRecord_t *measure_record =
+      (MeasurementRecord_t *) calloc (1, sizeof (MeasurementRecord_t));
+
+  MeasurementRecordItem_t *measure_record_item =
+      (MeasurementRecordItem_t *) calloc (1, sizeof (MeasurementRecordItem_t));
+  measure_record_item->present = MeasurementRecordItem_PR_real;
+  measure_record_item->choice.real = 0; //(rand() % 256) + 0.1;
+  // Stream measurement records to list.
+  ASN_SEQUENCE_ADD (&measure_record->list, measure_record_item);
+  MeasurementDataItem_t *measure_data_item =
+      (MeasurementDataItem_t *) calloc (1, sizeof (MeasurementDataItem_t));
+  measure_data_item->measRecord = *measure_record;
+
+  ASN_SEQUENCE_ADD (&measurement_data->list, measure_data_item);
+
+  // 2. TODO: Optional, but mandatory for flex ric "Fix warning commit".
+  MeasurementType_t *measurmentType = (MeasurementType_t *) calloc (1, sizeof (MeasurementType_t));
+  measurmentType->present = MeasurementType_PR_measName;
+  // DRB.RlcSduDelayDl
+  std::string name = "DRB.RlcSduDelayDl_Fake";
+  MeasurementTypeName_t *m_measName =
       (MeasurementTypeName_t *) calloc (1, sizeof (MeasurementTypeName_t));
   m_measName->buf = (uint8_t *) calloc (1, sizeof (OCTET_STRING));
   m_measName->size = name.length ();
   memcpy (m_measName->buf, name.c_str (), m_measName->size);
+  measurmentType->choice.measName = *m_measName;
+  MeasurementLabel_t *measure_label =
+      (MeasurementLabel_t *) calloc (1, sizeof (MeasurementLabel_t));
+  // TODO: add real plmnid from m_values.
+  // Ptr<OctetString> plmnid = Create<OctetString> ("3d9bf3", 3);
+  // measure_label->plmnID = plmnid->GetPointer();
+  measure_label->noLabel = (long *) malloc (sizeof (long));
+  assert (measure_label->noLabel != NULL && "Memory exhausted");
+  *measure_label->noLabel = 0;
+  LabelInfoItem_t *LabelInfoItem = (LabelInfoItem_t *) calloc (1, sizeof (LabelInfoItem_t));
+  LabelInfoItem->measLabel = *measure_label;
+  LabelInfoList_t *labelInfoolist = (LabelInfoList_t *) calloc (1, sizeof (LabelInfoList_t));
+  ASN_SEQUENCE_ADD (&labelInfoolist->list, LabelInfoItem);
+  MeasurementInfoItem_t *infoItem =
+      (MeasurementInfoItem_t *) calloc (1, sizeof (MeasurementInfoItem_t));
+  infoItem->labelInfoList = *labelInfoolist;
+  infoItem->measType = *measurmentType;
 
-  m_measurementItem->pmType.choice.measName = *m_measName;
-  m_measurementItem->pmType.present = MeasurementType_PR_measName;
+  MeasurementInfoList_t *infoList =
+      (MeasurementInfoList_t *) calloc (1, sizeof (MeasurementInfoList_t));
+  ASN_SEQUENCE_ADD (&infoList->list, infoItem);
 
-      */
-      MeasurementType_t * measurmentType = (MeasurementType_t *) calloc (1, sizeof (MeasurementType_t));
-      measurmentType->present = MeasurementType_PR_measName;
-      // DRB.RlcSduDelayDl
-      std::string name = "DRB.RlcSduDelayDl";
-      MeasurementTypeName_t * m_measName = (MeasurementTypeName_t *) calloc (1, sizeof (MeasurementTypeName_t));
-      m_measName->buf = (uint8_t *) calloc (1, sizeof (OCTET_STRING));
-      m_measName->size = name.length ();
-      memcpy (m_measName->buf, name.c_str (), m_measName->size);
+  // 3. Adding Granularity Period
+  GranularityPeriod_t *granPeriodMS =
+      (GranularityPeriod_t *) calloc (1, sizeof (GranularityPeriod_t));
+  *granPeriodMS = 100;
 
-      measurmentType->choice.measName = *m_measName;
+  ind_msg_f_1->measData = *measurement_data;
+  ind_msg_f_1->measInfoList = infoList;
+  ind_msg_f_1->granulPeriod = granPeriodMS;
 
-      MeasurementLabel_t * measure_label = (MeasurementLabel_t *) calloc(1, sizeof(MeasurementLabel_t));
+  // Print ASN from Indication Message, format 1.
+  NS_LOG_INFO (xer_fprint (stderr, &asn_DEF_E2SM_KPM_IndicationMessage_Format1, ind_msg_f_1));
+}
 
-      // TODO: add real plmnid from m_values.
-      // Ptr<OctetString> plmnid = Create<OctetString> ("3d9bf3", 3);
-      // measure_label->plmnID = plmnid->GetPointer();
-      measure_label->noLabel = (long *) malloc (sizeof(long));
-      assert (measure_label->noLabel != NULL && "Memory exhausted");
-      *measure_label->noLabel = 0;
+void
+KpmIndicationMessage::FillKpmIndicationMessageFormat1 (
+    E2SM_KPM_IndicationMessage_Format1 *ind_msg_f_1, const Ptr<MeasurementItemList> ueIndication)
+{
 
+  // 1. Adding a measurement values (item) to the packet.MeasurementRecord_t *measure_record =
+  // 2. Adding a Measurement Info Item(s), Optional, but mandatory for flex ric "Fix warning commit".
+  // TODO: Iterate over whole mesItems
+  MeasurementData_t *measurementDataList =
+      (MeasurementData_t *) calloc (1, sizeof (MeasurementData_t));
 
-      LabelInfoItem_t * LabelInfoItem = (LabelInfoItem_t *) calloc (1, sizeof (LabelInfoItem_t));
-      LabelInfoItem->measLabel = *measure_label;
+  MeasurementInfoList_t *infoList =
+      (MeasurementInfoList_t *) calloc (1, sizeof (MeasurementInfoList_t));
+  auto UE_MeasurementItems = ueIndication->GetItems ();
+  for (const auto &UE_MeasurementItem : UE_MeasurementItems)
+    {
+      auto _pairInfo = getMesInfoItem (UE_MeasurementItem);
 
-      LabelInfoList_t * labelInfoolist = (LabelInfoList_t *) calloc (1, sizeof (LabelInfoList_t));
-      ASN_SEQUENCE_ADD (&labelInfoolist->list, LabelInfoItem);
+      MeasurementInfoItem_t *infoItem = _pairInfo.first;
+      MeasurementDataItem_t *measureDataItem = _pairInfo.second;
 
-      MeasurementInfoItem_t * infoItem = (MeasurementInfoItem_t *) calloc (1, sizeof (MeasurementInfoItem_t));
-
-      infoItem->labelInfoList = *labelInfoolist;
-      infoItem->measType = *measurmentType;
-
-      MeasurementInfoList_t * infoList = (MeasurementInfoList_t *) calloc (1, sizeof (MeasurementInfoList_t));
+      ASN_SEQUENCE_ADD (&measurementDataList->list, measureDataItem);
       ASN_SEQUENCE_ADD (&infoList->list, infoItem);
-
-
-      // GranularityPeriod_t CollectiveTime = time_now_us();
-/*
-  msg_frm_1.gran_period_ms = calloc(1, sizeof(*msg_frm_1.gran_period_ms));
-  assert(msg_frm_1.gran_period_ms != NULL && "Memory exhausted");
-  *msg_frm_1.gran_period_ms = (rand() % 4294967295) + 1;
-*/
-
-      // 4. create Indication Message Format 1
-      E2SM_KPM_IndicationMessage_Format1_t *test_kpm_ind_message =
-          (E2SM_KPM_IndicationMessage_Format1_t *) calloc (
-              1, sizeof (E2SM_KPM_IndicationMessage_Format1_t));
-
-      test_kpm_ind_message->measData = *measurement_data;
-
-      test_kpm_ind_message->measInfoList = infoList;
-      // Print ASN from Indication Message, format 1.
-      NS_LOG_INFO (xer_fprint (stderr, &asn_DEF_E2SM_KPM_IndicationMessage_Format1, test_kpm_ind_message));
-
-      // Format 3 Part
-
-      E2SM_KPM_IndicationMessage_Format3_t *test_kpm_ind_message_format3 =
-          (E2SM_KPM_IndicationMessage_Format3_t *) calloc (
-              1, sizeof (E2SM_KPM_IndicationMessage_Format3_t));
-      assert (test_kpm_ind_message_format3 != nullptr && "Memory exhausted");
-
-      // TODOL Multi UEs
-      if(false && values.m_ueIndications.size() > 0) {
-          // arrayof<UEID_GNB_t> ues gnb_asn
-          NS_LOG_DEBUG("Mina NOWW values.m_ueIndications.size()= " << values.m_ueIndications.size());
-          // NS_LOG_INFO(values.m_ueIndications.size());
-
-          if(values.m_ueIndications.size() > 0) {
-
-          NS_LOG_DEBUG("2. NOWW values.m_ueIndications.size()= " << values.m_ueIndications.size());
-
-            UEMeasurementReportList_t* m_ueMeasReportList = (UEMeasurementReportList_t *) calloc (
-              values.m_ueIndications.size(), sizeof (UEMeasurementReportList_t));
-
-            // TODO: Empty m_ueIndications always!!!!!
-            int _index = 0;
-            for(auto ueIndication : values.m_ueIndications) {
-
-              UEMeasurementReportItem_t *UE_data =
-                  (UEMeasurementReportItem_t *) calloc (1, sizeof (UEMeasurementReportItem_t));
-
-              UEID_GNB_t *gnb_asn = (UEID_GNB_t *) calloc (1, sizeof (UEID_GNB_t));
-              assert (gnb_asn != NULL && "Memory exhausted");
-
-              gnb_asn->amf_UE_NGAP_ID.buf = (uint8_t *) calloc (5, sizeof (uint8_t));
-              assert (gnb_asn->amf_UE_NGAP_ID.buf != NULL && "Memory exhausted");
-
-              asn_ulong2INTEGER (&gnb_asn->amf_UE_NGAP_ID,
-              static_cast<unsigned long>(KpmIndicationHeader::octet_string_to_int_64(ueIndication->GetId())));
-
-              // gnb_asn->amf_UE_NGAP_ID =  static_cast<INTEGER_t>(KpmIndicationHeader::octet_string_to_int_64(ueIndication->GetId()));
-
-              gnb_asn->guami.aMFPointer = cp_amf_ptr_to_bit_string ((rand () % 2 ^ 6) + 0);
-              gnb_asn->guami.aMFSetID = cp_amf_set_id_to_bit_string ((rand () % 2 ^ 10) + 0);
-              gnb_asn->guami.aMFRegionID = cp_amf_region_id_to_bit_string ((rand () % 2 ^ 8) + 0);
-
-              gnb_asn->guami.pLMNIdentity = cp_plmn_identity_to_octant_string (rand() % 505, rand() % 99, 2);
-
-              // TODO
-              // gnb_asn->ran_UEID 
-
-              gnb_asn->ran_UEID = (RANUEID_t *) calloc(1, sizeof(*gnb_asn->ran_UEID));
-              gnb_asn->ran_UEID->buf = (uint8_t *) calloc(8, sizeof(*gnb_asn->ran_UEID->buf));
-              uint8_t ran_ue_id[8] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-              memcpy(gnb_asn->ran_UEID->buf, ran_ue_id, 8);
-              gnb_asn->ran_UEID->size = 8;
-              /* 
-                gnb_asn->ran_UEID->buf = calloc(8, sizeof(*gnb_asn->ran_UEID->buf));
-              */
-
-              UEID_t *ue_ID = (UEID_t *) calloc (1, sizeof (UEID_t));
-              ue_ID->present = UEID_PR_gNB_UEID;
-              ue_ID->choice.gNB_UEID = gnb_asn;
-
-              UE_data->ueID = *ue_ID;
-              UE_data->measReport = *test_kpm_ind_message;
-
-              // TODO
-              ASN_SEQUENCE_ADD(&m_ueMeasReportList[_index++].list, UE_data);
-
-
-              // test_kpm_ind_message_format3->ueMeasReportList.list[index] = UE_data;
-
-            }
-            test_kpm_ind_message_format3->ueMeasReportList = *m_ueMeasReportList;
-            // ASN_SEQUENCE_ADD (&test_kpm_ind_message_format3->ueMeasReportList.list, m_ueMeasReportList);
-          }
-      } else {
-          UEMeasurementReportItem_t *UE_data =
-                  (UEMeasurementReportItem_t *) calloc (1, sizeof (UEMeasurementReportItem_t));
-
-              UEID_GNB_t *gnb_asn = (UEID_GNB_t *) calloc (1, sizeof (UEID_GNB_t));
-              assert (gnb_asn != NULL && "Memory exhausted");
-
-              gnb_asn->amf_UE_NGAP_ID.buf = (uint8_t *) calloc (5, sizeof (uint8_t));
-              assert (gnb_asn->amf_UE_NGAP_ID.buf != NULL && "Memory exhausted");
-
-              // asn_ulong2INTEGER (&gnb_asn->amf_UE_NGAP_ID, rand() % 112358132134);
-              asn_ulong2INTEGER (&gnb_asn->amf_UE_NGAP_ID, 1);
-              // asn_ulong2INTEGER (&gnb_asn->amf_UE_NGAP_ID, 112358132134);
-
-
-              // dummy values
-              // gnb_asn->guami.aMFPointer = cp_amf_ptr_to_bit_string ((rand () % 2 ^ 6) + 0);
-              // gnb_asn->guami.aMFSetID = cp_amf_set_id_to_bit_string ((rand () % 2 ^ 10) + 0);
-              // gnb_asn->guami.aMFRegionID = cp_amf_region_id_to_bit_string ((rand () % 2 ^ 8) + 0);
-              gnb_asn->guami.aMFPointer = cp_amf_ptr_to_bit_string (0);
-              gnb_asn->guami.aMFSetID = cp_amf_set_id_to_bit_string (1);
-              gnb_asn->guami.aMFRegionID = cp_amf_region_id_to_bit_string (2 + 0);
-
-              // MCC_MNC_TO_PLMNID((uint16_t)(208), (uint16_t)(01) , (uint8_t)2, &gnb_asn->guami.pLMNIdentity);
-              // gnb_asn->guami.pLMNIdentity = cp_plmn_identity_to_octant_string (505, 01, 2);
-              gnb_asn->guami.pLMNIdentity = cp_plmn_identity_to_octant_string (rand() % 505, rand() % 99, 2);
-
-              // TODO
-              // gnb_asn->ran_UEID 
-              gnb_asn->ran_UEID = (RANUEID_t *) calloc(1, sizeof(*gnb_asn->ran_UEID));
-              gnb_asn->ran_UEID->buf = (uint8_t *) calloc(8, sizeof(*gnb_asn->ran_UEID->buf));
-              uint8_t ran_ue_id[8] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-              memcpy(gnb_asn->ran_UEID->buf, ran_ue_id, 8);
-              gnb_asn->ran_UEID->size = 8;
-
-              UEID_t *ue_ID = (UEID_t *) calloc (1, sizeof (UEID_t));
-              ue_ID->present = UEID_PR_gNB_UEID;
-              ue_ID->choice.gNB_UEID = gnb_asn;
-
-              UE_data->ueID = *ue_ID;
-
-              // Adding format 1 part with format 3 part.
-              UE_data->measReport = *test_kpm_ind_message;
-
-              // equivelent to code below -- old  code
-              // ASN_SEQUENCE_ADD (&UE_data_list->list,UE_data);
-              // test_kpm_ind_message_format3->ueMeasReportList = *UE_data_list ;
-              ASN_SEQUENCE_ADD (&test_kpm_ind_message_format3->ueMeasReportList.list, UE_data);
-      }
-
-      NS_LOG_INFO (xer_fprint (stderr, &asn_DEF_E2SM_KPM_IndicationMessage_Format3, test_kpm_ind_message_format3));
-
-      // NS_LOG_INFO (xer_fprint (stderr, &asn_DEF_E2SM_KPM_IndicationMessage, test_kpm_ind_message_format3));
-
-// asn_DEF_E2SM_KPM_IndicationMessage
-
-      ind_message->indicationMessage_formats.present =
-          E2SM_KPM_IndicationMessage__indicationMessage_formats_PR_indicationMessage_Format3;
-      ind_message->indicationMessage_formats.choice.indicationMessage_Format3 =
-          test_kpm_ind_message_format3;
-
-      NS_LOG_INFO (xer_fprint (stderr, &asn_DEF_E2SM_KPM_IndicationMessage, ind_message));
-
-      Encode (ind_message);
-
-      printf (" \n *** Done Encoding INDICATION Message ****** \n ");
     }
+
+  // 3. Adding Granularity Period
+  GranularityPeriod_t *granPeriodMS =
+      (GranularityPeriod_t *) calloc (1, sizeof (GranularityPeriod_t));
+  *granPeriodMS = 100;
+
+  ind_msg_f_1->measData = *measurementDataList;
+  ind_msg_f_1->measInfoList = infoList;
+  ind_msg_f_1->granulPeriod = granPeriodMS;
+
+  // Print ASN from Indication Message, format 1.
+  NS_LOG_INFO (xer_fprint (stderr, &asn_DEF_E2SM_KPM_IndicationMessage_Format1, ind_msg_f_1));
+}
+
+void
+KpmIndicationMessage::FillKpmIndicationMessageFormat3 (
+    E2SM_KPM_IndicationMessage_Format3 *ind_msg_f_3,
+    E2SM_KPM_IndicationMessage_Format1 *ind_msg_f_1, const KpmIndicationMessageValues &values)
+{
+
+  UEMeasurementReportItem_t *UE_data =
+      (UEMeasurementReportItem_t *) calloc (1, sizeof (UEMeasurementReportItem_t));
+
+  UEID_GNB_t *gnb_asn = (UEID_GNB_t *) calloc (1, sizeof (UEID_GNB_t));
+  assert (gnb_asn != NULL && "Memory exhausted");
+
+  gnb_asn->amf_UE_NGAP_ID.buf = (uint8_t *) calloc (5, sizeof (uint8_t));
+  assert (gnb_asn->amf_UE_NGAP_ID.buf != NULL && "Memory exhausted");
+
+  asn_ulong2INTEGER (&gnb_asn->amf_UE_NGAP_ID, rand () % 112358132134);
+  // RRU_PrbUsedDl
+  // dummy values
+  gnb_asn->guami.aMFPointer = cp_amf_ptr_to_bit_string ((rand () % 2 ^ 6) + 0);
+  gnb_asn->guami.aMFSetID = cp_amf_set_id_to_bit_string ((rand () % 2 ^ 10) + 0);
+  gnb_asn->guami.aMFRegionID = cp_amf_region_id_to_bit_string ((rand () % 2 ^ 8) + 0);
+
+  // MCC_MNC_TO_PLMNID((uint16_t)(208), (uint16_t)(01) , (uint8_t)2, &gnb_asn->guami.pLMNIdentity);
+  gnb_asn->guami.pLMNIdentity = cp_plmn_identity_to_octant_string (rand () % 505, rand () % 99, 2);
+
+  // TODO
+  // gnb_asn->ran_UEID
+  gnb_asn->ran_UEID = (RANUEID_t *) calloc (1, sizeof (*gnb_asn->ran_UEID));
+  gnb_asn->ran_UEID->buf = (uint8_t *) calloc (8, sizeof (*gnb_asn->ran_UEID->buf));
+  uint8_t ran_ue_id[8] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  memcpy (gnb_asn->ran_UEID->buf, ran_ue_id, 8);
+  gnb_asn->ran_UEID->size = 8;
+
+  UEID_t *ue_ID = (UEID_t *) calloc (1, sizeof (UEID_t));
+  ue_ID->present = UEID_PR_gNB_UEID;
+  ue_ID->choice.gNB_UEID = gnb_asn;
+
+  UE_data->ueID = *ue_ID;
+
+  // Adding format 1 part with format 3 part.
+  UE_data->measReport = *ind_msg_f_1;
+
+  // equivelent to code below -- old  code
+  // ASN_SEQUENCE_ADD (&UE_data_list->list,UE_data);
+  // kpm_ind_message_format3->ueMeasReportList = *UE_data_list ;
+  ASN_SEQUENCE_ADD (&ind_msg_f_3->ueMeasReportList.list, UE_data);
+
+  NS_LOG_INFO (xer_fprint (stderr, &asn_DEF_E2SM_KPM_IndicationMessage_Format3, ind_msg_f_3));
+}
+
+void
+KpmIndicationMessage::FillUeID (UEID_t *ue_ID, const Ptr<MeasurementItemList> ueIndication)
+{
+
+  // NS_LOG_UNCOND("Hooo" << ueIndication->GetId());
+  auto UEid = std::string (reinterpret_cast<const char *> (ueIndication->GetId ().buf),
+                           ueIndication->GetId ().size);
+  NS_LOG_INFO ("\n ID of current UE  " << UEid);
+
+  UEID_GNB_t *gnb_asn = (UEID_GNB_t *) calloc (1, sizeof (UEID_GNB_t));
+  assert (gnb_asn != NULL && "Memory exhausted");
+
+  gnb_asn->amf_UE_NGAP_ID.buf = (uint8_t *) calloc (5, sizeof (uint8_t));
+  assert (gnb_asn->amf_UE_NGAP_ID.buf != NULL && "Memory exhausted");
+
+  // asn_ulong2INTEGER (&gnb_asn->amf_UE_NGAP_ID, rand () % 112358132134);
+  asn_ulong2INTEGER (&gnb_asn->amf_UE_NGAP_ID,
+                     static_cast<unsigned long> (
+                         KpmIndicationHeader::octet_string_to_int_64 (ueIndication->GetId ())));
+
+  // gnb_asn->amf_UE_NGAP_ID =  static_cast<INTEGER_t>(KpmIndicationHeader::octet_string_to_int_64(ueIndication->GetId()));
+
+  gnb_asn->guami.aMFPointer = cp_amf_ptr_to_bit_string ((rand () % 2 ^ 6) + 0);
+  gnb_asn->guami.aMFSetID = cp_amf_set_id_to_bit_string ((rand () % 2 ^ 10) + 0);
+  gnb_asn->guami.aMFRegionID = cp_amf_region_id_to_bit_string ((rand () % 2 ^ 8) + 0);
+
+  gnb_asn->guami.pLMNIdentity = cp_plmn_identity_to_octant_string (rand () % 505, rand () % 99, 2);
+  // gnb_asn->guami.pLMNIdentity = ueIndication->GetId (); !!!!!!
+
+  // TODO
+  // gnb_asn->ran_UEID
+
+  gnb_asn->ran_UEID = (RANUEID_t *) calloc (1, sizeof (*gnb_asn->ran_UEID));
+  gnb_asn->ran_UEID->buf = (uint8_t *) calloc (8, sizeof (*gnb_asn->ran_UEID->buf));
+  uint8_t ran_ue_id[8] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  memcpy (gnb_asn->ran_UEID->buf, ran_ue_id, 8);
+  gnb_asn->ran_UEID->size = 8;
+
+  gnb_asn->ran_UEID->buf = (uint8_t *) calloc (8, sizeof (*gnb_asn->ran_UEID->buf));
+
+  // UEID_t *ue_ID = (UEID_t *) calloc (1, sizeof (UEID_t));
+  ue_ID->present = UEID_PR_gNB_UEID;
+  ue_ID->choice.gNB_UEID = gnb_asn;
+}
+
+void
+KpmIndicationMessage::FillKpmIndicationMessageFormat3 (
+    E2SM_KPM_IndicationMessage_Format3 *ind_msg_f_3, const KpmIndicationMessageValues &values)
+{
+
+  UEMeasurementReportList_t *m_ueMeasReportList =
+      (UEMeasurementReportList_t *) calloc (1, sizeof (UEMeasurementReportList_t));
+
+  // For each indication message fill UE fill values.
+  for (const auto &ueIndication : values.m_ueIndications)
+    {
+
+      UEMeasurementReportItem_t *UE_data =
+          (UEMeasurementReportItem_t *) calloc (1, sizeof (UEMeasurementReportItem_t));
+
+      UEID_t *ue_ID = (UEID_t *) calloc (1, sizeof (UEID_t));
+
+      E2SM_KPM_IndicationMessage_Format1 *ind_msg_f_1 =
+          (E2SM_KPM_IndicationMessage_Format1 *) calloc (
+              1, sizeof (E2SM_KPM_IndicationMessage_Format1));
+
+      FillUeID (ue_ID, ueIndication);
+      FillKpmIndicationMessageFormat1 (ind_msg_f_1, ueIndication);
+
+      UE_data->ueID = *ue_ID;
+      UE_data->measReport = *ind_msg_f_1;
+
+      // TODO
+      ASN_SEQUENCE_ADD (&m_ueMeasReportList->list, UE_data);
+    }
+
+  ind_msg_f_3->ueMeasReportList = *m_ueMeasReportList;
+}
+
+// NR = New Radio(5G)
+// EUTRA = 4G
+// CSI = Channel State Information
+// SSB = synchronization signal block (SSB) in 5G New Radio (NR).
+void
+KpmIndicationMessage::FillAndEncodeKpmIndicationMessage (
+    E2SM_KPM_IndicationMessage_t *descriptor, KpmIndicationMessageValues values,
+    const E2SM_KPM_IndicationMessage_FormatType &format_type)
+{
+
+  // Fill the RAN container.
+  // PF_Container_t *ranContainer = (PF_Container_t *) calloc (1, sizeof (PF_Container_t));
+  // FillPmContainer (ranContainer, values.m_pmContainerValues);
+
+  // Fill the message
+  // PM_Containers_Item_t *containers_list =
+  //     (PM_Containers_Item_t *) calloc (1, sizeof (PM_Containers_Item_t));
+  // containers_list->performanceContainer = ranContainer;
+
+  E2SM_KPM_IndicationMessage_t *ind_message =
+      (E2SM_KPM_IndicationMessage_t *) calloc (1, sizeof (E2SM_KPM_IndicationMessage_t));
+
+  switch (format_type)
+    {
+      case E2SM_KPM_INDICATION_MESSAGE_FORMART1: {
+        // Format 1
+        // E2SM_KPM_IndicationMessage_Format1_t *kpm_ind_message_format1 =
+        //     (E2SM_KPM_IndicationMessage_Format1_t *) calloc (
+        //         1, sizeof (E2SM_KPM_IndicationMessage_Format1_t));
+        // FillKpmIndicationMessageFormat1 (kpm_ind_message_format1, values);
+        // ind_message->indicationMessage_formats.present =
+        //     E2SM_KPM_IndicationMessage__indicationMessage_formats_PR_indicationMessage_Format1;
+        // // ASN_SEQUENCE_ADD(&ind_message->indicationMessage_formats.choice.indicationMessage_Format1,
+        // // kpm_ind_message_format1) ;
+        // ind_message->indicationMessage_formats.choice.indicationMessage_Format1 =
+        //     kpm_ind_message_format1;
+        break;
+      }
+      case E2SM_KPM_INDICATION_MESSAGE_FORMART2: {
+        break;
+      }
+      case E2SM_KPM_INDICATION_MESSAGE_FORMART3: {
+
+        // Format 3 section, consists of format 1 and some additional args
+        // like (UE_ID, and Measurements report) and these are mandatory args.
+        E2SM_KPM_IndicationMessage_Format3_t *kpm_ind_message_format3 =
+            (E2SM_KPM_IndicationMessage_Format3_t *) calloc (
+                1, sizeof (E2SM_KPM_IndicationMessage_Format3_t));
+
+        assert (kpm_ind_message_format3 != nullptr && "Memory exhausted");
+        NS_LOG_DEBUG ("2. NOWW values.m_ueIndications.size()=" << values.m_ueIndications.size ());
+
+        // if (values.m_cellMeasurementItems) {
+
+        // }
+        if (values.m_ueIndications.size () > 0)
+          {
+            FillKpmIndicationMessageFormat3 (kpm_ind_message_format3, values);
+          }
+        else
+          {
+            // return;
+            E2SM_KPM_IndicationMessage_Format1_t *kpm_ind_message_format1 =
+                (E2SM_KPM_IndicationMessage_Format1_t *) calloc (
+                    1, sizeof (E2SM_KPM_IndicationMessage_Format1_t));
+
+            FillKpmIndicationMessageFormat1 (kpm_ind_message_format1);
+
+            FillKpmIndicationMessageFormat3 (kpm_ind_message_format3, kpm_ind_message_format1,
+                                             values);
+          }
+
+        ind_message->indicationMessage_formats.present =
+            E2SM_KPM_IndicationMessage__indicationMessage_formats_PR_indicationMessage_Format3;
+        ind_message->indicationMessage_formats.choice.indicationMessage_Format3 =
+            kpm_ind_message_format3;
+
+        break;
+      }
+    default:
+      break;
+    }
+
+  NS_LOG_INFO (xer_fprint (stderr, &asn_DEF_E2SM_KPM_IndicationMessage, ind_message));
+  Encode (ind_message);
+  printf (" \n *** Done Encoding INDICATION Message ****** \n ");
 }
 
 MeasurementItemList::MeasurementItemList ()

--- a/model/kpm-indication.h
+++ b/model/kpm-indication.h
@@ -21,6 +21,7 @@
  * Author: Andrea Lacava <thecave003@gmail.com>
  *		   Tommaso Zugno <tommasozugno@gmail.com>
  *		   Michele Polese <michele.polese@gmail.com>
+ *       Mina Yonan <mina.awadallah@orange.com>
  *		   Mostafa Ashraf <mostafa.ashraf.ext@orange.com>
  *       Aya Kamal <aya.kamal.ext@orange.com>
  *       Abdelrhman Soliman <abdelrhman.soliman.ext@orange.com>
@@ -33,90 +34,132 @@
 #include "ns3/object.h"
 #include <set>
 
+#include <thread>
+#include <mutex>
+
 #include <vector>
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
 
-extern "C" {  
-  #include "E2SM-KPM-RANfunction-Description.h"
-  #include "E2SM-KPM-IndicationHeader.h"
-  #include "E2SM-KPM-IndicationMessage.h"
-  #include "RAN-Container.h"
-  #include "PF-Container.h"
-  #include "OCUUP-PF-Container.h"
-  #include "OCUCP-PF-Container.h"
-  #include "ODU-PF-Container.h"
-  #include "PF-ContainerListItem.h"
-  #include "asn1c-types.h"
+extern "C" {
+#include "E2SM-KPM-RANfunction-Description.h"
+#include "E2SM-KPM-IndicationHeader.h"
+#include "E2SM-KPM-IndicationMessage.h"
+#include "RAN-Container.h"
+#include "PF-Container.h"
+#include "OCUUP-PF-Container.h"
+#include "OCUCP-PF-Container.h"
+#include "ODU-PF-Container.h"
+#include "PF-ContainerListItem.h"
+#include "asn1c-types.h"
 
 //===================================
 
+#include "E2SM-KPM-IndicationHeader-Format1.h"
+#include "E2SM-KPM-IndicationMessage-Format1.h"
+#include "GlobalE2node-ID.h"
+#include "GlobalE2node-gNB-ID.h"
+#include "GlobalE2node-eNB-ID.h"
+#include "GlobalE2node-ng-eNB-ID.h"
+#include "GlobalE2node-en-gNB-ID.h"
+#include "NRCGI.h"
+#include "PM-Containers-Item.h"
+#include "RIC-EventTriggerStyle-Item.h"
+#include "RIC-ReportStyle-Item.h"
+#include "TimeStamp.h"
+#include "CUUPMeasurement-Container.h"
+#include "PlmnID-Item.h"
+#include "EPC-CUUP-PM-Format.h"
+#include "PerQCIReportListItemFormat.h"
+#include "PerUE-PM-Item.h"
+#include "PM-Info-Item.h"
+#include "MeasurementInfoList.h"
+#include "CellObjectID.h"
+#include "CellResourceReportListItem.h"
+#include "ServedPlmnPerCellListItem.h"
+#include "EPC-DU-PM-Container.h"
+#include "PerQCIReportListItem.h"
+//==============================================================
+#include "MeasurementRecordItem.h"
+#include "MeasurementDataItem.h"
+#include "MeasurementInfoItem.h"
+#include "LabelInfoItem.h"
+#include "MeasurementLabel.h"
+#include "E2SM-KPM-IndicationMessage-Format3.h"
+#include "UEMeasurementReportItem.h"
+#include "UEID-GNB.h"
 }
 
 namespace ns3 {
 
-  class KpmIndicationHeader : public SimpleRefCount<KpmIndicationHeader>
-  {
-  public:
-    enum GlobalE2nodeType { gNB = 0, eNB = 1, ng_eNB = 2, en_gNB = 3 };
+enum E2SM_KPM_IndicationMessage_FormatType {
+  E2SM_KPM_INDICATION_MESSAGE_FORMART1 = 0,
+  E2SM_KPM_INDICATION_MESSAGE_FORMART2,
+  E2SM_KPM_INDICATION_MESSAGE_FORMART3
+};
 
-    const static int TIMESTAMP_LIMIT_SIZE = 8;
-    /**
+class KpmIndicationHeader : public SimpleRefCount<KpmIndicationHeader>
+{
+public:
+  enum GlobalE2nodeType { gNB = 0, eNB = 1, ng_eNB = 2, en_gNB = 3 };
+
+  const static int TIMESTAMP_LIMIT_SIZE = 8;
+  /**
     * Holds the values to be used to fill the RIC Indication header 
     */
-    struct KpmRicIndicationHeaderValues
-    {
-      // E2SM-KPM Indication Header Format 1
-      // KPM Node ID IE
-      std::string m_gnbId; //!< gNB ID bit string 
-      // TODO not supported
-      // uint64_t m_cuUpId; //!< gNB-CU-UP ID, integer [0, 2^36-1], optional
-      
-      // Cell Global ID (NR CGI) IE
-      uint16_t m_nrCellId; //!< NR, bit string
-      
-      // PLMN ID IE
-      std::string m_plmId; //!< PLMN identity, octet string, 3 bytes
-      
-      // Slice ID (S-NSSAI) IE // TODO not supported
-      // std::string m_sst; //!< SNSSAI sST, 1 byte
-      // std::string m_sd; //!< SNSSAI sD, 3 bytes, optional
-      
-      // FiveQI IE // TODO not supported
-      // uint8_t m_fiveqi; //!< fiveQI, integer [0, 255], optional
-      
-      // QCI IE // TODO not supported
-      // long m_qci; //!< QCI, integer [0, 255], optional
-      
-      // TODO this value is placed in a fiels which seems not to be defined 
-      // in the specs. See line 301 in encode_kpm.cpp
-      // the field is called gNB_DU_ID
-      // it should be part of KPM Node ID IE
-      // m_duId
-    
-      // TODO this value is placed in a fiels which seems not to be defined 
-      // in the specs. See line 290 in encode_kpm.cpp, the field is called
-      // gNB_Name
-      // m_cuUpName
-      
-      // CollectionTimeStamp
-      uint64_t m_timestamp;
-    };
-    
-    KpmIndicationHeader (GlobalE2nodeType nodeType,KpmRicIndicationHeaderValues values);
-    ~KpmIndicationHeader ();
+  struct KpmRicIndicationHeaderValues
+  {
+    // E2SM-KPM Indication Header Format 1
+    // KPM Node ID IE
+    std::string m_gnbId; //!< gNB ID bit string
+    // TODO not supported
+    // uint64_t m_cuUpId; //!< gNB-CU-UP ID, integer [0, 2^36-1], optional
 
-    uint64_t time_now_us_clck();
-    OCTET_STRING_t get_time_now_us();
-    static uint64_t octet_string_to_int_64(OCTET_STRING_t asn);
-    static OCTET_STRING_t int_64_to_octet_string(uint64_t value);
+    // Cell Global ID (NR CGI) IE
+    uint16_t m_nrCellId; //!< NR, bit string
 
-    void* m_buffer;
-    size_t m_size;
-    
-  private: 
-    /**
+    // PLMN ID IE
+    std::string m_plmId; //!< PLMN identity, octet string, 3 bytes
+
+    // Slice ID (S-NSSAI) IE // TODO not supported
+    // std::string m_sst; //!< SNSSAI sST, 1 byte
+    // std::string m_sd; //!< SNSSAI sD, 3 bytes, optional
+
+    // FiveQI IE // TODO not supported
+    // uint8_t m_fiveqi; //!< fiveQI, integer [0, 255], optional
+
+    // QCI IE // TODO not supported
+    // long m_qci; //!< QCI, integer [0, 255], optional
+
+    // TODO this value is placed in a fiels which seems not to be defined
+    // in the specs. See line 301 in encode_kpm.cpp
+    // the field is called gNB_DU_ID
+    // it should be part of KPM Node ID IE
+    // m_duId
+
+    // TODO this value is placed in a fiels which seems not to be defined
+    // in the specs. See line 290 in encode_kpm.cpp, the field is called
+    // gNB_Name
+    // m_cuUpName
+
+    // CollectionTimeStamp
+    uint64_t m_timestamp;
+  };
+
+  KpmIndicationHeader (GlobalE2nodeType nodeType, KpmRicIndicationHeaderValues values);
+  ~KpmIndicationHeader ();
+
+  uint64_t time_now_us_clck ();
+  OCTET_STRING_t get_time_now_us ();
+  static uint64_t octet_string_to_int_64 (OCTET_STRING_t asn);
+  static OCTET_STRING_t int_64_to_octet_string (uint64_t value);
+
+  void *m_buffer;
+  size_t m_size;
+
+private:
+  /**
     * Fills the KPM INDICATION Header descriptor
     * This function fills the RIC Indication Header with the provided 
     * values
@@ -124,221 +167,250 @@ namespace ns3 {
     * \param descriptor object representing the KPM INDICATION Header
     * \param values struct holding the values to be used to fill the header 
     */
-    void FillAndEncodeKpmRicIndicationHeader (E2SM_KPM_IndicationHeader_t* descriptor, 
-                                              KpmRicIndicationHeaderValues values);
-    
-    void Encode (E2SM_KPM_IndicationHeader_t* descriptor);
+  void FillAndEncodeKpmRicIndicationHeader (E2SM_KPM_IndicationHeader_t *descriptor,
+                                            KpmRicIndicationHeaderValues values);
 
-    GlobalE2nodeType m_nodeType;
-    };
+  void Encode (E2SM_KPM_IndicationHeader_t *descriptor);
 
-  class MeasurementItemList : public SimpleRefCount<MeasurementItemList>
+  GlobalE2nodeType m_nodeType;
+};
+
+class MeasurementItemList : public SimpleRefCount<MeasurementItemList>
+{
+private:
+  Ptr<OctetString> m_id; // ID, contains the UE IMSI if used to carry UE-specific measurement items
+  std::vector<Ptr<MeasurementItem>> m_items; //!< list of Measurement Information Items
+public:
+  MeasurementItemList ();
+  MeasurementItemList (std::string ueId);
+  ~MeasurementItemList ();
+
+  // NOTE defined here to avoid undefined references
+  template <class T>
+  void
+  AddItem (std::string name, T value)
   {
-  private:
-    Ptr<OctetString> m_id; // ID, contains the UE IMSI if used to carry UE-specific measurement items
-    std::vector<Ptr<MeasurementItem>> m_items; //!< list of Measurement Information Items
-  public:
-    MeasurementItemList ();
-    MeasurementItemList (std::string ueId);
-     ~MeasurementItemList ();
+    Ptr<MeasurementItem> item = Create<MeasurementItem> (name, value);
+    m_items.push_back (item);
+  }
 
-    // NOTE defined here to avoid undefined references
-    template<class T> 
-    void AddItem (std::string name, T value)
-    {
-      Ptr<MeasurementItem> item = Create<MeasurementItem> (name, value);
-      m_items.push_back (item);
-    }
-    
-    std::vector<Ptr<MeasurementItem>> GetItems();
-    OCTET_STRING_t GetId ();
-  };
+  std::vector<Ptr<MeasurementItem>> GetItems ();
+  OCTET_STRING_t GetId ();
+};
 
-  /**
+/**
   * Base class to carry PM Container values  
-  */    
-  class PmContainerValues : public SimpleRefCount<PmContainerValues> 
-  {
-  public:
-    virtual ~PmContainerValues () = default;
-  };
+  */
+class PmContainerValues : public SimpleRefCount<PmContainerValues>
+{
+public:
+  virtual ~PmContainerValues () = default;
+};
 
-  /**
+/**
   * Contains the values to be inserted in the O-CU-CP Measurement Container  
   */
-  class OCuCpContainerValues : public PmContainerValues
-  {
-  public:
-    uint16_t m_numActiveUes; //!< mean number of RRC connections
-  };
-  
-  /**
+class OCuCpContainerValues : public PmContainerValues
+{
+public:
+  uint16_t m_numActiveUes; //!< mean number of RRC connections
+};
+
+/**
   * Contains the values to be inserted in the O-CU-UP Measurement Container  
   */
-  class OCuUpContainerValues : public PmContainerValues
-  {
-  public:
-    std::string m_plmId; //!< PLMN identity, octet string, 3 bytes
-    long m_pDCPBytesUL; //!< total PDCP bytes transmitted UL
-    long m_pDCPBytesDL; //!< total PDCP bytes transmitted DL
-  };
+class OCuUpContainerValues : public PmContainerValues
+{
+public:
+  std::string m_plmId; //!< PLMN identity, octet string, 3 bytes
+  long m_pDCPBytesUL; //!< total PDCP bytes transmitted UL
+  long m_pDCPBytesDL; //!< total PDCP bytes transmitted DL
+};
 
-  /**
+/**
   * Contains the values to be inserted in the O-DU EPC Measurement Container  
   */
-  class EpcDuPmContainer : public SimpleRefCount<EpcDuPmContainer>
-  {
-  public:
-    long m_qci; //!< QCI value
-    long m_dlPrbUsage; //!< Used number of PRBs in an average of DL for the monitored slice during E2 reporting period
-    long m_ulPrbUsage; //!< Used number of PRBs in an average of UL for the monitored slice during E2 reporting period
-    virtual ~EpcDuPmContainer () = default;
-  };
+class EpcDuPmContainer : public SimpleRefCount<EpcDuPmContainer>
+{
+public:
+  long m_qci; //!< QCI value
+  long
+      m_dlPrbUsage; //!< Used number of PRBs in an average of DL for the monitored slice during E2 reporting period
+  long
+      m_ulPrbUsage; //!< Used number of PRBs in an average of UL for the monitored slice during E2 reporting period
+  virtual ~EpcDuPmContainer () = default;
+};
 
-  /**
+/**
   * Contains the values to be inserted in the O-DU 5GC Measurement Container  
   */
-  class FiveGcDuPmContainer : public SimpleRefCount<FiveGcDuPmContainer>
-  {
-  public:
-    // Snssai m_sliceId; //!< S-NSSAI
-    long m_fiveQi; //!< 5QI value
-    long m_dlPrbUsage; //!< Used number of PRBs in an average of DL for the monitored slice during E2 reporting period
-    long m_ulPrbUsage; //!< Used number of PRBs in an average of UL for the monitored slice during E2 reporting period
-    virtual ~FiveGcDuPmContainer () = default;
-  };
+class FiveGcDuPmContainer : public SimpleRefCount<FiveGcDuPmContainer>
+{
+public:
+  // Snssai m_sliceId; //!< S-NSSAI
+  long m_fiveQi; //!< 5QI value
+  long
+      m_dlPrbUsage; //!< Used number of PRBs in an average of DL for the monitored slice during E2 reporting period
+  long
+      m_ulPrbUsage; //!< Used number of PRBs in an average of UL for the monitored slice during E2 reporting period
+  virtual ~FiveGcDuPmContainer () = default;
+};
 
-  class ServedPlmnPerCell : public SimpleRefCount<ServedPlmnPerCell>
-  {
-  public:
-    std::string m_plmId; //!< PLMN identity, octet string, 3 bytes
-    uint16_t m_nrCellId;
-    std::set<Ptr<EpcDuPmContainer>> m_perQciReportItems;
-  };
+class ServedPlmnPerCell : public SimpleRefCount<ServedPlmnPerCell>
+{
+public:
+  std::string m_plmId; //!< PLMN identity, octet string, 3 bytes
+  uint16_t m_nrCellId;
+  std::set<Ptr<EpcDuPmContainer>> m_perQciReportItems;
+};
 
-  class CellResourceReport : public SimpleRefCount<CellResourceReport>
-  {
-  public:
-    std::string m_plmId; //!< PLMN identity, octet string, 3 bytes
-    uint16_t m_nrCellId;
-    long dlAvailablePrbs;
-    long ulAvailablePrbs;
-    std::set<Ptr<ServedPlmnPerCell>> m_servedPlmnPerCellItems;
-  };
+class CellResourceReport : public SimpleRefCount<CellResourceReport>
+{
+public:
+  std::string m_plmId; //!< PLMN identity, octet string, 3 bytes
+  uint16_t m_nrCellId;
+  long dlAvailablePrbs;
+  long ulAvailablePrbs;
+  std::set<Ptr<ServedPlmnPerCell>> m_servedPlmnPerCellItems;
+};
 
-  /**
+/**
   * Contains the values to be inserted in the O-DU Measurement Container  
   */
-  class ODuContainerValues : public PmContainerValues
-  {
-  public:
-    std::set<Ptr<CellResourceReport>> m_cellResourceReportItems;
-  };
+class ODuContainerValues : public PmContainerValues
+{
+public:
+  std::set<Ptr<CellResourceReport>> m_cellResourceReportItems;
+};
 
-  class KpmIndicationMessage : public SimpleRefCount<KpmIndicationMessage>
-  {
-  public:
-    
-    /**
+class KpmIndicationMessage : public SimpleRefCount<KpmIndicationMessage>
+{
+public:
+  /**
     * Holds the values to be used to fill the RIC Indication Message 
     */
-    struct KpmIndicationMessageValues
-    {
-      std::string m_cellObjectId; //!< Cell Object ID
-      Ptr<PmContainerValues> m_pmContainerValues; //!< struct containing values to be inserted in the PM Container
-      Ptr<MeasurementItemList> m_cellMeasurementItems; //!< list of cell-specific Measurement Information Items
-      std::set<Ptr<MeasurementItemList>> m_ueIndications; //!< list of Measurement Information Items
+  struct KpmIndicationMessageValues
+  {
+    std::string m_cellObjectId; //!< Cell Object ID
+    Ptr<PmContainerValues>
+        m_pmContainerValues; //!< struct containing values to be inserted in the PM Container
+    Ptr<MeasurementItemList>
+        m_cellMeasurementItems; //!< list of cell-specific Measurement Information Items
+    std::set<Ptr<MeasurementItemList>> m_ueIndications; //!< list of Measurement Information Items
+  };
+
+  KpmIndicationMessage (KpmIndicationMessageValues values);
+  ~KpmIndicationMessage ();
+
+  void *m_buffer;
+  size_t m_size;
+  // ======================================================================================
+  BIT_STRING_t
+  cp_amf_region_id_to_bit_string (uint8_t src)
+  {
+    assert (src < 64);
+
+    BIT_STRING_t dst = {
+        .buf = (uint8_t *) malloc (1),
+        .size = 1,
+        .bits_unused = 0,
     };
+    assert (dst.buf != NULL);
 
-    KpmIndicationMessage (KpmIndicationMessageValues values);
-    ~KpmIndicationMessage ();
-    
-    void* m_buffer;
-    size_t m_size;
-// ======================================================================================
-    BIT_STRING_t cp_amf_region_id_to_bit_string(uint8_t src)
-    {
-      assert(src < 64);    
-  
-      BIT_STRING_t dst = {.buf=(uint8_t*)malloc(1), .size = 1,.bits_unused = 0,}; 
-      assert(dst.buf != NULL);
-  
-      memcpy(dst.buf, &src, 1);    
-  
-  return dst;
-   }
+    memcpy (dst.buf, &src, 1);
 
+    return dst;
+  }
 
+  BIT_STRING_t
+  cp_amf_set_id_to_bit_string (uint16_t val)
+  {
+    assert (val < 1024);
 
-BIT_STRING_t cp_amf_set_id_to_bit_string(uint16_t val)
-{
-  assert(val < 1024);
+    BIT_STRING_t dst = {0};
+    dst.buf = (uint8_t *) calloc (2, sizeof (uint8_t));
+    dst.size = 2;
+    dst.bits_unused = 6; // unused_bit;
+    assert (dst.buf != NULL);
 
-  BIT_STRING_t dst = {0}; 
-  dst.buf = (uint8_t*)calloc(2, sizeof(uint8_t) ); 
-  dst.size = 2;
-  dst.bits_unused = 6; // unused_bit;
-  assert(dst.buf != NULL);
+    dst.buf[0] = val; // 0x5555;
+    dst.buf[1] = (val >> 8) << 6;
 
-  dst.buf[0] = val; // 0x5555;
-  dst.buf[1] = (val >> 8) << 6; 
+    return dst;
+  }
 
-  return dst;
-}
+  BIT_STRING_t
+  cp_amf_ptr_to_bit_string (uint8_t src)
+  {
+    assert (src < 64);
 
+    uint8_t tmp = src << 2;
 
-BIT_STRING_t cp_amf_ptr_to_bit_string(uint8_t src)
-{
-  assert(src < 64);
+    BIT_STRING_t dst = {.buf = (uint8_t *) malloc (1), .size = 1, .bits_unused = 2};
+    assert (dst.buf != NULL);
+    memcpy (dst.buf, &tmp, 1);
 
-  uint8_t tmp = src << 2;
+    return dst;
+  }
 
-  BIT_STRING_t dst = { .buf = (uint8_t*)malloc(1), .size = 1,.bits_unused =2}; 
-  assert(dst.buf != NULL);
-  memcpy(dst.buf, &tmp, 1); 
-
-  return dst;
-}
-
-OCTET_STRING_t cp_plmn_identity_to_octant_string (uint16_t mCC,uint16_t mNC, uint8_t mNCdIGITlENGTH)
-{
-    OCTET_STRING_t dst = {0} ; 
-    dst.buf = (uint8_t*)calloc(3, sizeof(uint8_t)); 
-    dst.buf[0] = ((((mCC) / 10) % 10) << 4) | (mCC/100); 
+  OCTET_STRING_t
+  cp_plmn_identity_to_octant_string (uint16_t mCC, uint16_t mNC, uint8_t mNCdIGITlENGTH)
+  {
+    OCTET_STRING_t dst = {0};
+    dst.buf = (uint8_t *) calloc (3, sizeof (uint8_t));
+    dst.buf[0] = ((((mCC) / 10) % 10) << 4) | (mCC / 100);
     dst.buf[1] = ((mNCdIGITlENGTH == 2 ? 15 : (mNC) / 100) << 4) | (mCC % 10);
     dst.buf[2] = (((mNC) % 10) << 4) | (((mNC) / 10) % 10);
-    dst.size = 3 ;     
-    return dst ;                                              
-}
+    dst.size = 3;
+    return dst;
+  }
 
-OCTET_STRING_t cp_plmn_identity_to_octant_string (uint8_t src)
-{
-    OCTET_STRING_t dst = {0} ; 
-    dst.buf = (uint8_t*)calloc(3, sizeof(uint8_t));
-    dst.buf[0] = src << 4  ; 
-    dst.buf[1] = src << 4 ; 
-    dst.buf[2] = src << 4 ; 
-    dst.size = 3 ;     
-    return dst ;                                              
-}
+  OCTET_STRING_t
+  cp_plmn_identity_to_octant_string (uint8_t src)
+  {
+    OCTET_STRING_t dst = {0};
+    dst.buf = (uint8_t *) calloc (3, sizeof (uint8_t));
+    dst.buf[0] = src << 4;
+    dst.buf[1] = src << 4;
+    dst.buf[2] = src << 4;
+    dst.size = 3;
+    return dst;
+  }
 
-//==================================================================================
+  //==================================================================================
+private:
+  static void CheckConstraints (KpmIndicationMessageValues values);
+  void FillPmContainer (PF_Container_t *ranContainer, Ptr<PmContainerValues> values);
+  void FillOCuUpContainer (PF_Container_t *ranContainer, Ptr<OCuUpContainerValues> values);
+  void FillOCuCpContainer (PF_Container_t *ranContainer, Ptr<OCuCpContainerValues> values);
+  void FillODuContainer (PF_Container_t *ranContainer, Ptr<ODuContainerValues> values);
+  void FillAndEncodeKpmIndicationMessage (E2SM_KPM_IndicationMessage_t *descriptor,
+                                          KpmIndicationMessageValues values,
+                                          const E2SM_KPM_IndicationMessage_FormatType &format_type =
+                                              E2SM_KPM_INDICATION_MESSAGE_FORMART3);
+  void Encode (E2SM_KPM_IndicationMessage_t *descriptor);
 
-    
-  private:
-    static void CheckConstraints (KpmIndicationMessageValues values);
-    void FillPmContainer (PF_Container_t *ranContainer, 
-                          Ptr<PmContainerValues> values);
-    void FillOCuUpContainer (PF_Container_t *ranContainer, 
-                            Ptr<OCuUpContainerValues> values);
-    void FillOCuCpContainer (PF_Container_t *ranContainer, 
-                             Ptr<OCuCpContainerValues> values);
-    void FillODuContainer (PF_Container_t *ranContainer, 
-                           Ptr<ODuContainerValues> values);
-    void FillAndEncodeKpmIndicationMessage (E2SM_KPM_IndicationMessage_t *descriptor,
-                                            KpmIndicationMessageValues values);
-    void Encode (E2SM_KPM_IndicationMessage_t *descriptor);
-  };
-}
+  void FillKpmIndicationMessageFormat1 (E2SM_KPM_IndicationMessage_Format1 *ind_msg_f_1,
+                                        const Ptr<MeasurementItemList> ueIndication);
+
+  void FillKpmIndicationMessageFormat1 (E2SM_KPM_IndicationMessage_Format1 *ind_msg_f_1);
+
+  void FillKpmIndicationMessageFormat3 (E2SM_KPM_IndicationMessage_Format3 *ind_msg_f_3,
+                                        E2SM_KPM_IndicationMessage_Format1 *ind_msg_f_1,
+                                        const KpmIndicationMessageValues &values);
+
+  void FillKpmIndicationMessageFormat3 (E2SM_KPM_IndicationMessage_Format3 *ind_msg_f_3,
+                                        const KpmIndicationMessageValues &values);
+
+  std::pair<MeasurementInfoItem_t *, MeasurementDataItem_t *>
+  getMesInfoItem (const Ptr<MeasurementItem> &mesItem);
+
+  MeasurementDataItem_t *getMesDataItem (const double &realVal);
+  MeasurementDataItem_t *getMesDataItem (const MeasResultListNR *_measResultListNR);
+  MeasurementDataItem_t *getMesDataItem (const MeasResultServMOList *_MeasResultServMOList);
+
+  void FillUeID (UEID_t *ue_ID, Ptr<MeasurementItemList> ueIndication);
+};
+} // namespace ns3
 
 #endif /* KPM_INDICATION_H */

--- a/model/kpm-indication.h
+++ b/model/kpm-indication.h
@@ -41,6 +41,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
+#include <any>
 
 extern "C" {
 #include "E2SM-KPM-RANfunction-Description.h"
@@ -90,7 +91,6 @@ extern "C" {
 #include "UEMeasurementReportItem.h"
 #include "UEID-GNB.h"
 }
-
 namespace ns3 {
 
 enum E2SM_KPM_IndicationMessage_FormatType {
@@ -298,8 +298,12 @@ public:
         m_cellMeasurementItems; //!< list of cell-specific Measurement Information Items
     std::set<Ptr<MeasurementItemList>> m_ueIndications; //!< list of Measurement Information Items
   };
-
-  KpmIndicationMessage (KpmIndicationMessageValues values);
+  
+   void SetSubscriptionRMap(const std::map<std::string, std::any>& newMap) 
+ {
+    SubscriptionR_map = newMap;
+ }
+  KpmIndicationMessage (KpmIndicationMessageValues values,const std::map<std::string, std::any> & s_map);
   ~KpmIndicationMessage ();
 
   void *m_buffer;
@@ -379,6 +383,7 @@ public:
 
   //==================================================================================
 private:
+  std::map<std::string, std::any> SubscriptionR_map;
   static void CheckConstraints (KpmIndicationMessageValues values);
   void FillPmContainer (PF_Container_t *ranContainer, Ptr<PmContainerValues> values);
   void FillOCuUpContainer (PF_Container_t *ranContainer, Ptr<OCuUpContainerValues> values);

--- a/model/kpm-indication.h
+++ b/model/kpm-indication.h
@@ -403,13 +403,21 @@ private:
                                         const KpmIndicationMessageValues &values);
 
   std::pair<MeasurementInfoItem_t *, MeasurementDataItem_t *>
-  getMesInfoItem (const Ptr<MeasurementItem> &mesItem);
+  getMesInfoItem (const Ptr<MeasurementItem> &mesItem, const OCTET_STRING_t &IMSI);
 
   MeasurementDataItem_t *getMesDataItem (const double &realVal);
-  MeasurementDataItem_t *getMesDataItem (const MeasResultListNR *_measResultListNR);
-  MeasurementDataItem_t *getMesDataItem (const MeasResultServMOList *_MeasResultServMOList);
+  MeasurementDataItem_t *getMesDataItem (const MeasResultListNR *_measResultListNR,
+                                         const OCTET_STRING_t &IMSI,
+                                         MeasurementType_t *measurmentType);
+  MeasurementDataItem_t *getMesDataItem (const MeasResultServMOList *_MeasResultServMOList,
+                                         const OCTET_STRING_t &IMSI,
+                                         MeasurementType_t *measurmentType);
 
   void FillUeID (UEID_t *ue_ID, Ptr<MeasurementItemList> ueIndication);
+
+  void updateServingMsg (MeasurementType_t *measurmentType, const int &cellID,
+                         const OCTET_STRING_t &IMSI);
+  void updateNeighMsg (MeasurementType_t *measurmentType, const OCTET_STRING_t &IMSI);
 };
 } // namespace ns3
 

--- a/model/kpm-indication.h
+++ b/model/kpm-indication.h
@@ -417,7 +417,7 @@ private:
 
   void updateServingMsg (MeasurementType_t *measurmentType, const int &cellID,
                          const OCTET_STRING_t &IMSI);
-  void updateNeighMsg (MeasurementType_t *measurmentType, const OCTET_STRING_t &IMSI);
+  void updateNeighMsg (MeasurementType_t *measurmentType, const OCTET_STRING_t &IMSI, const int &cellID);
 };
 } // namespace ns3
 

--- a/model/kpm-indication.h
+++ b/model/kpm-indication.h
@@ -298,12 +298,14 @@ public:
         m_cellMeasurementItems; //!< list of cell-specific Measurement Information Items
     std::set<Ptr<MeasurementItemList>> m_ueIndications; //!< list of Measurement Information Items
   };
-  
-   void SetSubscriptionRMap(const std::map<std::string, std::any>& newMap) 
- {
+
+  void
+  SetSubscriptionRMap (const std::map<std::string, std::any> &newMap)
+  {
     SubscriptionR_map = newMap;
- }
-  KpmIndicationMessage (KpmIndicationMessageValues values,const std::map<std::string, std::any> & s_map);
+  }
+  KpmIndicationMessage (KpmIndicationMessageValues values,
+                        const std::map<std::string, std::any> &s_map);
   ~KpmIndicationMessage ();
 
   void *m_buffer;
@@ -422,7 +424,8 @@ private:
 
   void updateServingMsg (MeasurementType_t *measurmentType, const int &cellID,
                          const OCTET_STRING_t &IMSI);
-  void updateNeighMsg (MeasurementType_t *measurmentType, const OCTET_STRING_t &IMSI, const int &cellID);
+  void updateNeighMsg (MeasurementType_t *measurmentType, const OCTET_STRING_t &IMSI,
+                       const int &cellID);
 };
 } // namespace ns3
 

--- a/model/oran-interface.cc
+++ b/model/oran-interface.cc
@@ -18,22 +18,48 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  * Author: Andrea Lacava <thecave003@gmail.com>
- *		   Tommaso Zugno <tommasozugno@gmail.com>
- *		   Michele Polese <michele.polese@gmail.com>
+ *         Tommaso Zugno <tommasozugno@gmail.com>
+ *         Michele Polese <michele.polese@gmail.com>
  */
 
 #include <ns3/oran-interface.h>
 #include <ns3/asn1c-types.h>
- 
 #include <ns3/log.h>
 #include <thread>
 #include "encode_e2apv1.hpp"
-#include<unistd.h>
+#include <unistd.h>
+#include <any>
+//#include <boost/any.hpp>
+#include <string>
+#include <map>
+#include <typeinfo>
+
 extern "C" {
   #include "RICsubscriptionRequest.h"
   #include "RICactionType.h"
   #include "ProtocolIE-Field.h"
   #include "InitiatingMessage.h"
+  #include "RICactionDefinition.h"
+  #include "RICsubsequentAction.h"
+  #include "E2SM-KPM-EventTriggerDefinition.h"
+  #include "E2SM-KPM-EventTriggerDefinition-Format1.h"
+  #include "E2SM-KPM-ActionDefinition.h"
+  #include "E2SM-KPM-ActionDefinition-Format4.h"
+  #include "MatchingUeCondPerSubList.h"
+  #include "MatchingUeCondPerSubItem.h"
+  #include "TestCondInfo.h"
+  #include "TestCond-Type.h"
+  #include "TestCond-Expression.h"
+  #include "TestCond-Value.h"
+  #include "E2SM-KPM-ActionDefinition-Format1.h"
+  #include "MeasurementInfoList.h"
+  #include "GranularityPeriod.h"
+  #include "CGI.h"
+  #include "MeasurementInfoItem.h"
+  #include "MeasurementType.h"
+  #include "LabelInfoList.h"
+  #include "LabelInfoItem.h"
+  #include "MeasurementLabel.h"
 }
 
 namespace ns3 {
@@ -53,6 +79,273 @@ TypeId E2Termination::GetTypeId ()
 E2Termination::E2Termination ()
 {
   NS_FATAL_ERROR("Do not use the default constructor");
+ // NS_LOG_INFO("E2Termination Constructor Called");
+    // subs_details.clear();
+}
+
+void E2Termination::StoreSubscriptionDetail(const std::string& key, const std::any& value)
+{
+    subs_details[key] = value;
+    NS_LOG_INFO("Stored Subscription Detail: " << key);
+}
+
+template<typename T>
+T E2Termination::GetSubscriptionDetail(const std::string& key, const T& defaultValue) const
+{
+    auto it = subs_details.find(key);
+    if (it != subs_details.end())
+    {
+        try
+        {
+            return std::any_cast<T>(it->second);
+        }
+        catch (const std::bad_any_cast&)
+        {
+            NS_LOG_WARN("Type mismatch when retrieving key: " << key);
+        }
+    }
+    return defaultValue;
+}
+
+void E2Termination::PrintSubscriptionDetails() const
+{
+    for (const auto& pair : subs_details) {
+    // Print the key
+    printf("%s: ", pair.first.c_str());
+
+        if (pair.second.type() == typeid(int)) {
+            printf("%d\n", std::any_cast<int>(pair.second));
+        } else if (pair.second.type() == typeid(std::string)) {
+            printf("%s\n", std::any_cast<std::string>(pair.second).c_str());
+        } else if (pair.second.type() == typeid(double)) {
+            printf("%f\n", std::any_cast<double>(pair.second));
+        } else if (pair.second.type() == typeid(uint64_t)) {
+            printf("%lu\n", std::any_cast<uint64_t>(pair.second));
+        } else {
+            printf("Unknown type\n");
+        }
+  
+}
+}
+
+void E2Termination::DecodeLabelInfo(MeasurementLabel_t* label) {
+      if (label->noLabel) {
+        StoreSubscriptionDetail("Measurement Label",std::string("No Label"));
+        //std::any_cast<std::string>
+    }
+    if (label->plmnID) {
+        StoreSubscriptionDetail("PLMN ID",std::string(reinterpret_cast<char*>(label->plmnID->buf)));
+        //std::any_cast<std::string>
+    }
+    if (label->fiveQI) {
+        StoreSubscriptionDetail("FiveQI",std::any_cast<int>(*label->fiveQI));
+    }
+    if (label->qFI) {
+        StoreSubscriptionDetail("QoS Flow Identifier",std::any_cast<int>(*label->qFI));
+    }
+    if (label->qCI) {
+        StoreSubscriptionDetail("QCI",std::any_cast<int>(*label->qCI));
+    }
+    if (label->startEndInd) {
+        StoreSubscriptionDetail("startEndInd",std::any_cast<int>(*label->startEndInd));
+    }
+    if (label->min) {
+        StoreSubscriptionDetail("min",std::any_cast<int>(*label->min));
+    }
+    if (label->max) {
+        StoreSubscriptionDetail("max",std::any_cast<int>(*label->max));
+    }
+    if (label->avg) {
+        StoreSubscriptionDetail("avg",std::any_cast<int>(*label->avg));
+    }
+}
+
+void E2Termination::DecodeRICEventTriggerDefinition(const uint8_t* buffer, size_t size) {
+    E2SM_KPM_EventTriggerDefinition_t* eventTriggerDef = NULL;
+
+    asn_dec_rval_t rval = asn_decode(
+        NULL, ATS_ALIGNED_BASIC_PER,
+        &asn_DEF_E2SM_KPM_EventTriggerDefinition,
+        (void**)&eventTriggerDef, buffer, size
+    );
+    assert(rval.code == RC_OK && "Event Trigger Definition decoding failed!");
+
+    if (eventTriggerDef->eventDefinition_formats.present == E2SM_KPM_EventTriggerDefinition__eventDefinition_formats_PR_eventDefinition_Format1) {
+        uint64_t reportingPeriod = eventTriggerDef->eventDefinition_formats.choice.eventDefinition_Format1->reportingPeriod;
+        StoreSubscriptionDetail("Event Trigger Definition Format",static_cast<int>(E2SM_KPM_EventTriggerDefinition__eventDefinition_formats_PR_eventDefinition_Format1));
+        StoreSubscriptionDetail("Reporting Period",std::any_cast<uint64_t>(reportingPeriod));
+    } else {
+        NS_LOG_DEBUG("Unknown or unsupported Event Trigger Definition Format");
+    }
+
+    ASN_STRUCT_FREE(asn_DEF_E2SM_KPM_EventTriggerDefinition, eventTriggerDef);
+}
+
+void E2Termination::DecodeRICActionDefinition(const uint8_t* buffer, size_t size) {
+    E2SM_KPM_ActionDefinition_t* actionDef = NULL;
+
+    asn_dec_rval_t rval = asn_decode(NULL, ATS_ALIGNED_BASIC_PER, &asn_DEF_E2SM_KPM_ActionDefinition, (void**)&actionDef, buffer, size);
+
+    assert(rval.code == RC_OK && "Action Definition decoding failed!");
+
+    StoreSubscriptionDetail("RIC Style Type", static_cast<int>(actionDef->ric_Style_Type));
+    switch (actionDef->actionDefinition_formats.present) {
+    case E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format1:
+        StoreSubscriptionDetail("Action Definition Format",static_cast<int>(E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format1));
+        break;
+    case E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format2:
+        StoreSubscriptionDetail("Action Definition Format",static_cast<int>(E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format2));
+        break;
+    case E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format3:
+        StoreSubscriptionDetail("Action Definition Format",static_cast<int>(E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format3));
+        break;
+    case E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format4: {
+        StoreSubscriptionDetail("Action Definition Format",static_cast<int>(E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format4));
+
+        E2SM_KPM_ActionDefinition_Format4_t* format4 = actionDef->actionDefinition_formats.choice.actionDefinition_Format4;
+        MatchingUeCondPerSubList_t* matchingList = &format4->matchingUeCondList;
+
+        for (int i = 0; i < matchingList->list.count; i++) {
+            MatchingUeCondPerSubItem_t* subItem = matchingList->list.array[i];
+            TestCondInfo_t* testCondInfo = &subItem->testCondInfo;
+            // printf("Condition %d:\n", i + 1);
+            switch (testCondInfo->testType.present) {
+                case TestCond_Type_PR_gBR:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_gBR));
+                    break;
+                case TestCond_Type_PR_aMBR:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_aMBR));
+                    break;
+                case TestCond_Type_PR_isStat:
+                   StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_isStat));
+                    break;
+                case TestCond_Type_PR_isCatM:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_isCatM));
+                    break;
+                case TestCond_Type_PR_rSRP:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_rSRP));
+                    break;
+                case TestCond_Type_PR_rSRQ:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_rSRQ));
+                    break;
+                case TestCond_Type_PR_ul_rSRP:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_ul_rSRP));
+                    break;
+                case TestCond_Type_PR_cQI:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_cQI));
+                    break;
+                case TestCond_Type_PR_fiveQI:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_fiveQI));
+                    break;
+                case TestCond_Type_PR_qCI:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_qCI));
+                    break;
+                case TestCond_Type_PR_sNSSAI:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_sNSSAI));
+                    break;
+                default:
+                    StoreSubscriptionDetail("Test Condition Type",static_cast<int>(TestCond_Type_PR_NOTHING));
+                    break;
+            }
+
+            if (*testCondInfo->testExpr == TestCond_Expression_equal) {
+                StoreSubscriptionDetail("Test Condition Expression",static_cast<int>(TestCond_Expression_equal));
+            }
+            else if (*testCondInfo->testExpr == TestCond_Expression_greaterthan) {
+                StoreSubscriptionDetail("Test Condition Expression",static_cast<int>(TestCond_Expression_greaterthan));
+            } else if (*testCondInfo->testExpr == TestCond_Expression_lessthan) {
+                StoreSubscriptionDetail("Test Condition Expression",static_cast<int>(TestCond_Expression_lessthan));
+            } else if (*testCondInfo->testExpr == TestCond_Expression_contains) {
+                StoreSubscriptionDetail("Test Condition Expression",static_cast<int>(TestCond_Expression_contains));
+            } else if (*testCondInfo->testExpr == TestCond_Expression_present) {
+                StoreSubscriptionDetail("Test Condition Expression",static_cast<int>(TestCond_Expression_present));
+            } else {
+            }
+
+            TestCond_Value_t* testValue = testCondInfo->testValue;
+            if (testValue) {
+                switch (testValue->present) {
+                    case TestCond_Value_PR_valueInt:
+                        StoreSubscriptionDetail("Test Condition Value",static_cast<int>(testValue->choice.valueInt));
+                        break;
+                    case TestCond_Value_PR_valueEnum:
+                        StoreSubscriptionDetail("Test Condition Value",static_cast<int>(testValue->choice.valueEnum));
+                        break;
+                    case TestCond_Value_PR_valueBool:
+                        StoreSubscriptionDetail("Test Condition Value",testValue->choice.valueBool);
+                        break;
+                    case TestCond_Value_PR_valueBitS:
+                        StoreSubscriptionDetail("Test Condition Value", testValue->choice.valueBitS.buf);
+                        break;
+                    case TestCond_Value_PR_valueOctS:
+                        StoreSubscriptionDetail("Test Condition Value", testValue->choice.valueOctS.buf);
+                        break;
+                    case TestCond_Value_PR_valuePrtS:
+                        StoreSubscriptionDetail("Test Condition Value", testValue->choice.valuePrtS.buf);
+                        break;
+                    case TestCond_Value_PR_valueReal:
+                        StoreSubscriptionDetail("Test Condition Value", testValue->choice.valueReal);
+                        break;
+                    default:
+                         break;
+                    }
+            } else {
+                   StoreSubscriptionDetail("Test Condition Value", NULL);
+            }
+
+            }
+        //////////////////////////////////////////
+        // Decode Subscription Info (Format1)
+        E2SM_KPM_ActionDefinition_Format1_t* subscriptionInfo = &format4->subscriptionInfo;
+         //printf("Decoding Subscription Info:\n");
+        uint64_t granularityPeriod = subscriptionInfo->granulPeriod;
+        StoreSubscriptionDetail("Granularity Period",std::any_cast<uint64_t>(granularityPeriod));
+        MeasurementInfoList_t* measInfoList = &subscriptionInfo->measInfoList;
+        if (measInfoList->list.count == 0) {
+            // printf("Measurement Info List is empty\n");
+        } else {
+            //printf("Measurement Info List:\n");
+            for (int i = 0; i < measInfoList->list.count; i++) {
+            MeasurementInfoItem_t* measItem = measInfoList->list.array[i];
+            //printf("Measurement Item %d:\n", i + 1);
+            
+            if (measItem->measType.present == MeasurementType_PR_measName) {
+              StoreSubscriptionDetail("Measurement Name",std::string(reinterpret_cast<char*>(measItem->measType.choice.measName.buf)));
+              //std::any_cast<std::string>
+            } else {
+              //printf("Measurement Type: Unknown or unsupported\n");
+            }
+            
+            // Decode label info list
+            LabelInfoList_t* labelInfoList = &measItem->labelInfoList;
+            if (labelInfoList->list.count == 0) {
+                //printf("  Label Info List is empty\n");
+            } else {
+                // printf("  Label Info List:\n");
+                for (int j = 0; j < labelInfoList->list.count; j++) {
+                    LabelInfoItem_t* labelItem = labelInfoList->list.array[j];
+                   // printf("    Label Item %d:\n", j + 1);
+                    DecodeLabelInfo(&labelItem->measLabel);
+                }
+            }
+        }}
+      ////////////////////////////////
+        break;
+    }
+
+    case E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format5:
+        StoreSubscriptionDetail("Action Definition Format", static_cast<int>(E2SM_KPM_ActionDefinition__actionDefinition_formats_PR_actionDefinition_Format5));
+        break;
+
+    default:
+        printf("Unknown or unsupported Action Definition Format\n");
+        break;
+}
+    ASN_STRUCT_FREE(asn_DEF_E2SM_KPM_ActionDefinition, actionDef);
+}
+
+const Subscription_map& E2Termination::SubscriptionMapRef() const{
+  return subs_details; 
 }
 
 E2Termination::E2Termination(const std::string ricAddress, 
@@ -68,7 +361,6 @@ E2Termination::E2Termination(const std::string ricAddress,
 {
   NS_LOG_FUNCTION (this);
   m_e2sim = new E2Sim;
-  
   // create a new file which will be used to trace the encoded messages
   // TODO create an appropriate log class to handle these messages
   // FILE* f = fopen ("messages.txt", "w");
@@ -83,7 +375,6 @@ E2Termination::RegisterFunctionDescToE2Sm (long ranFunctionId, Ptr<FunctionDescr
   rfdBuf->buf = (uint8_t *) calloc (1, ranFunctionDescription->m_size);
   rfdBuf->size = ranFunctionDescription->m_size;
   memcpy (rfdBuf->buf, ranFunctionDescription->m_buffer, ranFunctionDescription->m_size);
-
   m_e2sim->register_e2sm (ranFunctionId, rfdBuf);
 }
 
@@ -122,7 +413,7 @@ void E2Termination::Start ()
 void E2Termination::DoStart ()
 {
   NS_LOG_FUNCTION (this);
-  
+
   // start e2sim main loop
   // char second[14]; // RIC ADDRESS
   // std::strcpy (second, m_ricAddress.c_str ());
@@ -151,22 +442,23 @@ E2Termination::~E2Termination ()
 
 E2Termination::RicSubscriptionRequest_rval_s 
 E2Termination::ProcessRicSubscriptionRequest (E2AP_PDU_t* sub_req_pdu)
-{
+{  
   //Record RIC Request ID
   //Go through RIC action to be Setup List
   //Find first entry with REPORT action Type
   //Record ricActionID
   //Encode subscription response
 
-  RICsubscriptionRequest_t orig_req = sub_req_pdu->choice.initiatingMessage->value.choice.RICsubscriptionRequest;
+  RICsubscriptionRequest_t *orig_req =(RICsubscriptionRequest_t*)calloc(1, sizeof(RICsubscriptionRequest_t));
+
+  orig_req=&sub_req_pdu->choice.initiatingMessage->value.choice.RICsubscriptionRequest;
 
   // RICsubscriptionResponse_IEs_t *ricreqid = (RICsubscriptionResponse_IEs_t*)calloc(1, sizeof(RICsubscriptionResponse_IEs_t));
            
-  int count = orig_req.protocolIEs.list.count;
-  int size = orig_req.protocolIEs.list.size;
+  int count = orig_req->protocolIEs.list.count;
+  int size = orig_req->protocolIEs.list.size;
 
-  RICsubscriptionRequest_IEs_t **ies = (RICsubscriptionRequest_IEs_t**)orig_req.protocolIEs.list.array;
-
+  RICsubscriptionRequest_IEs_t **ies = (RICsubscriptionRequest_IEs_t**)orig_req->protocolIEs.list.array;
   NS_LOG_DEBUG ("Number of IEs " << count);
   NS_LOG_DEBUG ("Size of IEs " << size);
 
@@ -185,6 +477,8 @@ E2Termination::ProcessRicSubscriptionRequest (E2AP_PDU_t* sub_req_pdu)
   {
     RICsubscriptionRequest_IEs_t *next_ie = ies[i];
     pres = next_ie->value.present; // value of the current IE
+   // std::cout << "IE " << i << ": pres = " << static_cast<int>(pres) 
+     //         << ", IE type = " << next_ie->id << std::endl;
       
     switch(pres) 
     {
@@ -211,16 +505,22 @@ E2Termination::ProcessRicSubscriptionRequest (E2AP_PDU_t* sub_req_pdu)
         {
           NS_LOG_DEBUG ("Processing RIC Subscription Details field");
           RICsubscriptionDetails_t subDetails = next_ie->value.choice.RICsubscriptionDetails;
-          
           // RIC Event Trigger Definition
           RICeventTriggerDefinition_t triggerDef = subDetails.ricEventTriggerDefinition;
-
+          ////////////////////////
           // TODO How to decode this field?
-          uint8_t size = 20;  
-          uint8_t *buf = (uint8_t *)calloc(1,size);
-          memcpy(buf, &triggerDef, size);
-          NS_LOG_DEBUG ("RIC Event Trigger Definition " << std::to_string (*buf));
-                    
+          // uint8_t size = 20;  
+           //uint8_t *buf = (uint8_t *)calloc(1,size);
+           //memcpy(buf, &triggerDef.buf, size);
+           //DecodeRICEventTriggerDefinition(buf, size);
+
+           const uint8_t* buf = triggerDef.buf; 
+           size_t size_event_trigger = triggerDef.size;  
+          DecodeRICEventTriggerDefinition(buf, size_event_trigger);
+          NS_LOG_DEBUG ("RIC Event Trigger Definition " << std::to_string (*buf)); 
+          //NS_LOG_DEBUG("Size of Event Trigger Definition: " <<size);
+
+   
           // Sequence of actions
           RICactions_ToBeSetup_List_t actionList = subDetails.ricAction_ToBeSetup_List;
           // TODO We are ignoring the trigger definition
@@ -236,7 +536,9 @@ E2Termination::ProcessRicSubscriptionRequest (E2AP_PDU_t* sub_req_pdu)
             auto *next_item = item_array[i];
             RICactionID_t actionId = ((RICaction_ToBeSetup_ItemIEs*)next_item)->value.choice.RICaction_ToBeSetup_Item.ricActionID;
             RICactionType_t actionType = ((RICaction_ToBeSetup_ItemIEs*)next_item)->value.choice.RICaction_ToBeSetup_Item.ricActionType;
-                        
+         RICactionDefinition_t* actiondef = ((RICaction_ToBeSetup_ItemIEs*)next_item)->value.choice.RICaction_ToBeSetup_Item.ricActionDefinition;
+         RICsubsequentAction_t* subsequentact=((RICaction_ToBeSetup_ItemIEs*)next_item)->value.choice.RICaction_ToBeSetup_Item.ricSubsequentAction;         
+            
             //We identify the first action whose type is REPORT
             //That is the only one accepted; all others are rejected
             if (!foundAction && (actionType == RICactionType_report || actionType == RICactionType_insert))
@@ -245,6 +547,24 @@ E2Termination::ProcessRicSubscriptionRequest (E2AP_PDU_t* sub_req_pdu)
               actionIdsAccept.push_back(reqActionId);
               NS_LOG_DEBUG ("Action ID " << actionId << " accepted");
               foundAction = true;
+              NS_LOG_DEBUG ("Action Type " << actionType << "\n");
+              ////////////////////
+              // RIC Action Definition. Optional 
+              if (actiondef!=NULL) {
+               uint8_t* buf_ad = (uint8_t*)calloc(1, actiondef->size);
+              if (buf_ad) {
+               memcpy(buf_ad, actiondef->buf, actiondef->size);
+               NS_LOG_DEBUG("RIC Action Definition: " << std::to_string(*buf_ad));
+               DecodeRICActionDefinition(buf_ad, actiondef->size);
+               }}
+
+        if (subsequentact!=NULL){
+          NS_LOG_DEBUG("Subsequent Action Type: " << subsequentact->ricSubsequentActionType);
+        if (subsequentact->ricTimeToWait) {
+            NS_LOG_DEBUG("Time to Wait: " << subsequentact->ricTimeToWait);
+        }
+    }
+    ////////////////////////////////////////
             } 
             else 
             {
@@ -261,8 +581,12 @@ E2Termination::ProcessRicSubscriptionRequest (E2AP_PDU_t* sub_req_pdu)
           break;
         }      
       }
+      // subsDetails_r
+          // printf("The map:\n");
+           //NS_LOG_INFO("Printing the map of Subscription Request details");
+            PrintSubscriptionDetails();
+            printf("Size of subsDetails_r: %ld\n", SubscriptionMapRef().size());
   }
-  
   NS_LOG_DEBUG ("Create RIC Subscription Response");
   
   E2AP_PDU *e2ap_pdu = (E2AP_PDU*)calloc(1,sizeof(E2AP_PDU));

--- a/model/oran-interface.h
+++ b/model/oran-interface.h
@@ -32,6 +32,10 @@
 // #include <ns3/ric-delete-function-description.h>
 #include <ns3/ric-control-message.h>
 #include "e2sim.hpp"
+#include <map>  
+#include <any>  
+
+typedef std::map<std::string, std::any> Subscription_map;
 
 namespace ns3 {
   
@@ -132,7 +136,7 @@ namespace ns3 {
       * \return RIC subscription request parameters
       */
       RicSubscriptionRequest_rval_s ProcessRicSubscriptionRequest (E2AP_PDU_t* sub_req_pdu);
-
+      
       /**
       * Sends an E2 message to the RIC
       * This function encodes and sends an E2 message to the RIC
@@ -140,7 +144,14 @@ namespace ns3 {
       * \param pdu the PDU of the message
       */
       void SendE2Message (E2AP_PDU* pdu);   
-
+      void StoreSubscriptionDetail(const std::string& key, const std::any& value);
+     template<typename T>
+    T GetSubscriptionDetail(const std::string& key, const T& defaultValue) const;
+      void PrintSubscriptionDetails() const;
+      void DecodeLabelInfo(MeasurementLabel_t* label);
+      void DecodeRICEventTriggerDefinition(const uint8_t* buffer, size_t size);
+      void DecodeRICActionDefinition(const uint8_t* buffer, size_t size);
+    const Subscription_map& SubscriptionMapRef() const;
     private:
       /**
       * Run the e2sim main loop.
@@ -164,6 +175,7 @@ namespace ns3 {
       uint16_t m_clientPort; //!< local bind port
       std::string m_gnbId; //!< GNB id
       std::string m_plmnId; //!< PLMN Id
+      Subscription_map subs_details; 
   };
 }
 

--- a/model/ric-control-message.cc
+++ b/model/ric-control-message.cc
@@ -73,7 +73,7 @@ RicControlMessage::DecodeRicControlMessage(E2AP_PDU_t* pdu)
                     }
                     case 1002: {
                         NS_LOG_DEBUG("QoS xApp message");
-                        m_requestType = ControlMessageRequestIdType::QoS;
+                        m_requestType = ControlMessageRequestIdType::Es;
                         break;
                     }
                     case 1024: {

--- a/model/ric-control-message.cc
+++ b/model/ric-control-message.cc
@@ -65,27 +65,37 @@ RicControlMessage::DecodeRicControlMessage(E2AP_PDU_t* pdu)
             case RICcontrolRequest_IEs__value_PR_RICrequestID: {
                 NS_LOG_DEBUG("[E2SM] RICcontrolRequest_IEs__value_PR_RICrequestID");
                 m_ricRequestId = ie->value.choice.RICrequestID;
-                switch (m_ricRequestId.ricRequestorID) {
-                    case 1001: {
-                        NS_LOG_DEBUG("HO xApp message");
-                        m_requestType = ControlMessageRequestIdType::HO;
+                /*switch (m_ricRequestId.ricRequestorID) {
+                    case 1: {
+                        NS_LOG_DEBUG("Radio Bearer Control");
+                       // m_requestType = ControlMessageRequestIdType::Connected_Mode_Mobility;
+                       m_requestType = ControlMessageServiceStyle::Radio_Bearer_Control;
                         break;
                     }
-                    case 1002: {
-                        NS_LOG_DEBUG("QoS xApp message");
-                        m_requestType = ControlMessageRequestIdType::Es;
+                    case 2: {
+                        NS_LOG_DEBUG("Radio Resource Allocation Control");
+                        //m_requestType = ControlMessageRequestIdType::Es;
+                        m_requestType = ControlMessageServiceStyle::Radio_Resource_Allocation_Control;
                         break;
                     }
-                    case 1024: {
-                        NS_LOG_DEBUG("RC xApp message");
-                        m_requestType = ControlMessageRequestIdType::RC;
+                    case 3: {
+                        NS_LOG_DEBUG("Connected Mode Mobility");
+                        //m_requestType = ControlMessageRequestIdType::RC;
+                        m_requestType = ControlMessageServiceStyle::Connected_Mode_Mobility;
+                        break;
+                    }
+                     case 300: {
+                        NS_LOG_DEBUG("Energy saving state custom control service style");
+                        //m_requestType = ControlMessageRequestIdType::RC;
+                        m_requestType = ControlMessageServiceStyle::Energy_state;
                         break;
                     }
                     default:
-                        NS_LOG_DEBUG("Unhandled ricRequestorID\n");
-                        m_requestType = static_cast<ControlMessageRequestIdType>(m_ricRequestId.ricRequestorID);
+                        NS_LOG_DEBUG("Unhandled Control Service Style\n");
+                        //m_requestType = static_cast<ControlMessageRequestIdType>(m_ricRequestId.ricRequestorID);
+                        m_requestType = static_cast<ControlMessageServiceStyle>(m_ricRequestId.ricRequestorID);
                         break;
-                }
+                }*/
                 break;
             }
             case RICcontrolRequest_IEs__value_PR_RANfunctionID: {
@@ -182,7 +192,8 @@ RicControlMessage::DecodeRicControlMessage(E2AP_PDU_t* pdu)
                             RicControlMessage::ExtractRANParametersFromControlMessage (e2SmRcControlMessageFormat1);
                         
                         NS_LOG_DEBUG("*** DONE ExtractRANParametersFromControlMessage **");
-                        if (m_requestType == ControlMessageRequestIdType::HO)
+                       // if (m_requestType == ControlMessageRequestIdType::HO)
+                        if (m_requestType == ControlMessageServiceStyle::Connected_Mode_Mobility)
                         {
                             // Get and parse the secondaty cell id according to 3GPP TS 38.473, Section 9.2.2.1
                             for (RANParameterItem item : m_valuesExtracted)

--- a/model/ric-control-message.cc
+++ b/model/ric-control-message.cc
@@ -65,8 +65,8 @@ RicControlMessage::DecodeRicControlMessage(E2AP_PDU_t* pdu)
                 m_ricRequestId = ie->value.choice.RICrequestID;
                 switch (m_ricRequestId.ricRequestorID) {
                     case 1001: {
-                        NS_LOG_DEBUG("TS xApp message");
-                        m_requestType = ControlMessageRequestIdType::TS;
+                        NS_LOG_DEBUG("HO xApp message");
+                        m_requestType = ControlMessageRequestIdType::HO;
                         break;
                     }
                     case 1002: {
@@ -180,7 +180,7 @@ RicControlMessage::DecodeRicControlMessage(E2AP_PDU_t* pdu)
                             RicControlMessage::ExtractRANParametersFromControlMessage (e2SmRcControlMessageFormat1);
                         
                         NS_LOG_DEBUG("*** DONE ExtractRANParametersFromControlMessage **");
-                        if (m_requestType == ControlMessageRequestIdType::TS)
+                        if (m_requestType == ControlMessageRequestIdType::HO)
                         {
                             // Get and parse the secondaty cell id according to 3GPP TS 38.473, Section 9.2.2.1
                             for (RANParameterItem item : m_valuesExtracted)
@@ -243,7 +243,35 @@ RicControlMessage::DecodeRicControlMessage(E2AP_PDU_t* pdu)
 
 std::string
 RicControlMessage::GetSecondaryCellIdHO ()
-{
+{ 
+   bool decode =false;
+    if (decode)
+        { 
+        //     E2SM_RC_ControlMessage_Format1_Item_t *RAN_pram1 = (E2SM_RC_ControlMessage_Format1_Item_t *) 
+        //                             calloc (1,sizeof(E2SM_RC_ControlMessage_Format1_Item_t));
+            
+        //     RAN_pram1 =controlMessage->m_e2SmRcControlMessageFormat1->ranP_List.list.array[0];
+                     
+        //    RANParameter_ValueType_Choice_Structure_t *CHOICE_Target_Cell =  (RANParameter_ValueType_Choice_Structure_t *) 
+        //                             calloc (1,sizeof(RANParameter_ValueType_Choice_Structure_t));
+        
+        //     CHOICE_Target_Cell = &RAN_pram1->ranParameter_valueType.choice.ranP_Choice_Structure->ranParameter_Structure->sequence_of_ranParameters.list.array[0];
+
+
+
+        //     RANParameter_ValueType_Choice_ElementFalse* RAN_pram1_valueType= (RANParameter_ValueType_Choice_ElementFalse_t *) 
+        //                             calloc (1,sizeof(RANParameter_ValueType_Choice_ElementFalse_t));
+            
+        //      RAN_pram1_valueType= RAN_pram1->ranParameter_valueType.choice.ranP_Choice_ElementFalse;
+
+
+        //     RANParameter_Value_t * NR_CGI = (RANParameter_Value_t *) 
+        //                             calloc (1,sizeof(RANParameter_Value_t));
+            
+        //     NR_CGI = &RAN_pram1_valueType->ranParameter_value->choice.valueInt;   
+         }
+
+          
   return m_secondaryCellId;
 }
 

--- a/model/ric-control-message.h
+++ b/model/ric-control-message.h
@@ -62,7 +62,7 @@ namespace ns3 {
     E2SM_RC_ControlHeader_Format1_t *m_e2SmRcControlHeaderFormat1;
     E2SM_RC_ControlMessage_Format1 *m_e2SmRcControlMessageFormat1;
     std::string GetSecondaryCellIdHO ();
-
+    uint16_t GetTargetCell() const;
   private:
     /**
     * Decodes the RIC Control message .

--- a/model/ric-control-message.h
+++ b/model/ric-control-message.h
@@ -46,7 +46,7 @@ namespace ns3 {
   class RicControlMessage : public SimpleRefCount<RicControlMessage>
   {
   public:
-    enum ControlMessageRequestIdType { HO = 3, QoS = 1002, RC=1024 };
+    enum ControlMessageRequestIdType { HO = 3, Es = 300, RC=1024 };
     RicControlMessage (E2AP_PDU_t *pdu);
     ~RicControlMessage ();
 

--- a/model/ric-control-message.h
+++ b/model/ric-control-message.h
@@ -46,7 +46,7 @@ namespace ns3 {
   class RicControlMessage : public SimpleRefCount<RicControlMessage>
   {
   public:
-    enum ControlMessageRequestIdType { TS = 1001, QoS = 1002, RC=1024 };
+    enum ControlMessageRequestIdType { HO = 3, QoS = 1002, RC=1024 };
     RicControlMessage (E2AP_PDU_t *pdu);
     ~RicControlMessage ();
 

--- a/model/ric-control-message.h
+++ b/model/ric-control-message.h
@@ -46,12 +46,13 @@ namespace ns3 {
   class RicControlMessage : public SimpleRefCount<RicControlMessage>
   {
   public:
-    enum ControlMessageRequestIdType { HO = 3, Es = 300, RC=1024 };
+    enum ControlMessageServiceStyle {Radio_Bearer_Control=1,Radio_Resource_Allocation_Control=2, Connected_Mode_Mobility = 3, Energy_state = 300};
+    enum Connected_Mode_Mobility_Control_Action_ID {Handover_Control=1,Conditional_Handover_Control=2,DAPS_Handover_Control=3};
     RicControlMessage (E2AP_PDU_t *pdu);
     ~RicControlMessage ();
 
-    ControlMessageRequestIdType m_requestType;
-    
+   
+    ControlMessageServiceStyle m_requestType;
     static std::vector<RANParameterItem> ExtractRANParametersFromControlMessage (
       E2SM_RC_ControlMessage_Format1_t *e2SmRcControlMessageFormat1);
     


### PR DESCRIPTION
## Description
- Updated KPM Indication Msg reporting, conversion from L3_RRC_Measurements of UEs to new KPM version 3.
- Added new methods to handle filing parameters for improved processing.
- Refined the reporting mechanism for L3 serving and neighboring cells.
- Updated the ControlMessageRequestIdType for enhanced compatibility.
- Added GetTargetCell() function in RicControlMessage to improve target cell retrieval.
- Enhanced handling of switch-off functionality.
- Expanded ric_control_message to include different ric control styles and action types.
- Updated neighbor cell message handling for more accurate reporting.
- Supported the decoding of SubReqMsg and forwarded relevant data to KPMIndicationMsg.

Fixes:
[34](https://github.com/Orange-OpenSource/ns-O-RAN-flexric/issues/34), [29](https://github.com/Orange-OpenSource/ns-O-RAN-flexric/issues/29), [15](https://github.com/Orange-OpenSource/ns-O-RAN-flexric/issues/15).
